### PR TITLE
Add PE Error For Missing Dependencies in ModDepMgr

### DIFF
--- a/src/Basic/moddepmgr.cc
+++ b/src/Basic/moddepmgr.cc
@@ -34,9 +34,8 @@ OD::ModDepMgr::ModDepMgr( const char* mdfnm )
     od_istream strm( moddepfnm );
     if ( !strm.isOK() )
     {
-	if ( DBG::isOn(DBG_PROGSTART) )
-	    DBG::message( BufferString( "Cannot read module dependencies from ",
-					moddepfnm ) );
+    pErrMsg( BufferString("Cannot read module dependencies from ",
+		moddepfnm ) );
 	return;
     }
 

--- a/src/Basic/moddepmgr.cc
+++ b/src/Basic/moddepmgr.cc
@@ -34,8 +34,8 @@ OD::ModDepMgr::ModDepMgr( const char* mdfnm )
     od_istream strm( moddepfnm );
     if ( !strm.isOK() )
     {
-    pErrMsg( BufferString("Cannot read module dependencies from ",
-		moddepfnm ) );
+    uiString msg = strm.errMsg();
+    pErrMsg( BufferString("Missing module dependency. ", msg ) );
 	return;
     }
 


### PR DESCRIPTION
Added an error message using `pErrMsg` to log failures when reading module dependencies for the specified file (ModDeps.od). This ensures clearer debugging information for cases where the file cannot be accessed or read.