### PR TITLE
Fix test_oscommand and test_pythoncomm

### DIFF
--- a/src/Basic/CMakeLists.txt
+++ b/src/Basic/CMakeLists.txt
@@ -165,25 +165,27 @@ if ( IS_DIRECTORY "${CMAKE_SOURCE_DIR}/external/safety" )
 	   "__safety_dir__=\"${CMAKE_SOURCE_DIR}/external/safety\"" )
 endif()
 
-if ( NOT ${BUILDINSRC} )
-    if ( UNIX )
-	set( FILEEXT sh )
-    else()
-	set( FILEEXT cmd )
-    endif()
-    file( COPY "${CMAKE_SOURCE_DIR}/testscripts/script with space.${FILEEXT}"
-	  DESTINATION "${PROJECT_BINARY_DIR}/testscripts" )
-    file( COPY "${CMAKE_SOURCE_DIR}/testscripts/count_to_1000.csh"
-	  DESTINATION "${PROJECT_BINARY_DIR}/testscripts" )
+if ( UNIX )
+set( FILEEXT sh )
+else()
+set( FILEEXT cmd )
+endif()
 
+file( COPY "${CMAKE_SOURCE_DIR}/testscripts/script with space.${FILEEXT}"
+  DESTINATION "${PROJECT_BINARY_DIR}/${MISC_INSTALL_PREFIX}/bin" )
+file( COPY "${CMAKE_SOURCE_DIR}/testscripts/count_to_1000.csh"
+  DESTINATION "${PROJECT_BINARY_DIR}/${MISC_INSTALL_PREFIX}/bin" )
+
+if ( NOT ${BUILDINSRC} )
     if ( UNIX )
 	set( FILEEXT sh )
     else()
 	set( FILEEXT bat )
     endif()
     file( COPY "${CMAKE_SOURCE_DIR}/bin/od_external.${FILEEXT}"
-	  DESTINATION "${PROJECT_BINARY_DIR}/bin" )
+	  DESTINATION "${PROJECT_BINARY_DIR}/${MISC_INSTALL_PREFIX}/bin" )
 endif()
+unset( FILEEXT )
 
 OD_INIT_MODULE()
 

--- a/src/Basic/tests/oscommand.cc
+++ b/src/Basic/tests/oscommand.cc
@@ -135,8 +135,7 @@ static bool testAllPipes()
 
 static bool runCommandWithSpace()
 {
-    FilePath scriptfp( GetSoftwareDir(0), "testscripts",
-			    "script with space");
+    FilePath scriptfp( GetScriptDir(), "script with space");
 #ifdef __win__
     scriptfp.setExtension( "cmd" );
 #else
@@ -159,8 +158,7 @@ static bool runCommandWithLongOutput()
     //Should be 100% correct, meaning that no bytes have been skipped or
     //inserted.
     //
-    const FilePath scriptfp( GetSoftwareDir(0), "testscripts",
-				 "count_to_1000.csh" );
+    const FilePath scriptfp( GetScriptDir(), "count_to_1000.csh" );
     BufferString output, errmsg;
     OS::MachineCommand machcomm( scriptfp.fullPath() );
     mRunStandardTestWithError( machcomm.execute(output,&errmsg),


### PR DESCRIPTION
Ensures all testscases in  test_oscommand and test_pythoncomm runs successfully on macos.

Changes
- Change the target location of testscripts on macos to be the MISC_INSTALL_PREFIX/bin directory on cmake.
- Ensure the test_oscommand fetches the required script files from the right directory using the GetScriptDir() function.
- The following files ( script with space.sh, count_to_1000.csh, od_external.sh ) are now located at {BUILDDIR}/Contents/Resources/bin on MacOS