### PR TITLE
Fix debug config path while running macos tests

### DIFF
--- a/testscripts/run_test.csh
+++ b/testscripts/run_test.csh
@@ -96,6 +96,8 @@ set kernel=`uname -a | awk '{print $1}'`
 
 if ( "${kernel}" == "Darwin" ) then
     set bindir="${wdir}/Contents/MacOS"
+    if ( "${config}" == "Debug" ) then
+    set bindir="${bindir}/Debug"
 else
     set bindir="${wdir}/bin/${plf}/${config}"
 endif


### PR DESCRIPTION
Adds a check to ensure that the right bin directory is set if config is set to "Debug" for Darwin kernel when using run_test.csh script to run all tests.