### PR TITLE
Fix python access on macos

### DIFF
--- a/src/Basic/pythonaccess.cc
+++ b/src/Basic/pythonaccess.cc
@@ -1293,6 +1293,10 @@ bool OD::PythonAccess::getInternalEnvironmentLocation( FilePath& fp,
     }
 
     fp.set( GetSoftwareDir(false) );
+    
+    if (__ismac__)
+        fp.set( fp.pathOnly() );
+    
     DirList dl( fp.pathOnly(), File::DirListType::DirsInDir );
     const BufferStringSet::idx_type defidx = dl.nearestMatch( "Python" );
     if ( dl.validIdx(defidx) )


### PR DESCRIPTION
This PR ensures that the python internal environment is properly discoverable on MacOS builds. This change is to ensure that the right file path is being set while searching for the Python environment.