### PR TITLE
Fix pythonaccess setup for windows

### DIFF
--- a/src/Basic/pythonaccess.cc
+++ b/src/Basic/pythonaccess.cc
@@ -725,6 +725,7 @@ FilePath* OD::PythonAccess::getCommand( OS::MachineCommand& cmd,
     BufferString temppath( File::getTempPath() );
     if ( temppath.find(' ') )
 	temppath.quote();
+	BufferString sourcecmd("source ");
 
 #ifdef __win__
     strm.add( "@SETLOCAL" ).add( od_newline );
@@ -742,7 +743,6 @@ FilePath* OD::PythonAccess::getCommand( OS::MachineCommand& cmd,
 #else
     strm.add( "#!/bin/bash" ).add( od_newline ).add( od_newline )
     	.add( "export TMPDIR=" ).add( temppath ).add( od_newline );
-    BufferString sourcecmd("source ");
     sourcecmd.add( activatefp->fullPath() );
     if ( envnm )
     {


### PR DESCRIPTION
This PR fixes the error below introduced by https://github.com/OpendTect/OpendTect/pull/18
E:\Users\dgb\dev\buildscripts\od\build\dgb112_win64_od_Release_Continuous_24284\main_od_source\src\Basic\pythonaccess.cc(790): error C2065: 'sourcecmd': undeclared identifier
