### PR TITLE
Fix stalled exit when closing via the X on the main window.

### DIFF
--- a/src/uiODMain/uiodmain.cc
+++ b/src/uiODMain/uiodmain.cc
@@ -975,6 +975,12 @@ bool uiODMain::closeOK( bool withinteraction, bool doconfirm )
 	 }
      }
 
+
+     //Clean up all scenes manually. If QT closes it down, it will trigger new rendering,
+     //which required GL context, which is only partial.
+     if ( scenemgr_ )
+        scenemgr_->cleanUp(false);
+
      beforeExit.trigger();
 
      if ( failed_ )


### PR DESCRIPTION
When OpendTect is closed (at least on Ubuntu 24.04) via the "X" on the main window, OpendTect does not exit but stalls. Exiting via the Survey->Exit menu works.

When closing through the X, QT starts destroying the tree of QObjects, and OD tries to clean up as well. In particular,
uiGroupObjBody::closeEvent is triggered from qt close event through the stack
uiObjectBody::uiCloseOK (on main window object)
uiObject::closeOK
Notifier
uiMdiArea::grpClosed
QMdiArea::removeSubWindow
QWidget::setParent
QWidgetPrivate::inheritStyle
...
QOpenGLContext::create
QXcbIntegration::createPlatformOpenGLContext

So it is triggering a new render and a new OpenGL context, while the system is half half-way deleted. This leads to as stall on condition variables deep down in glx/opengl.

When closing via the meny, the teardown is led from OD, and that works as the OpenGL context is still happy. This is mimicking that behavior.