### PR TITLE
Geobody

### DIFF
--- a/include/uiODMain/uiodbodydisplaytreeitem.h
+++ b/include/uiODMain/uiodbodydisplaytreeitem.h
@@ -89,6 +89,7 @@ private:
     MenuItem				displayintersectionmnuitem_;
     MenuItem				singlecolormnuitem_;
     MenuItem				volcalmnuitem_;
+    MenuItem				closepolygonmnuitem_;
 
     ConstRefMan<visSurvey::PolygonBodyDisplay> getPBDisplay() const;
     ConstRefMan<visSurvey::MarchingCubesDisplay> getMCDisplay() const;

--- a/include/visSurvey/vispicksetdisplay.h
+++ b/include/visSurvey/vispicksetdisplay.h
@@ -72,8 +72,19 @@ public:
 
     void			redrawAll(int draggeridx=-1);
 
-    void			fillPar(IOPar&) const override;
-    bool			usePar(const IOPar&) override;
+	void			fillPar(IOPar&) const override;
+	bool			usePar(const IOPar&) override;
+
+	void			setOnlyAtSectionsDisplay(bool) override;
+	bool			displayedOnlyAtSections() const override;
+
+	void			erasePointsBetweenDragPositions();
+	void			erasePointsNearPosition(const Coord3&);
+
+	bool			iserasing_	= false;
+	Coord3			erasestartpos_	= Coord3::udf();
+	Coord3			eraseendpos_	= Coord3::udf();
+	bool			displayonlyatsections_ = false;
 
 protected:
 			~PickSetDisplay();
@@ -107,25 +118,25 @@ protected:
 
     void			turnOnSelectionMode(bool) override;
     void			polygonFinishedCB(CallBacker*);
-    void			updateSelections(
-					    const visBase::PolygonSelection*);
-    bool			updateMarkerAtSection(const SurveyObject*,int);
-    void			updateLineAtSection();
+	void			updateSelections(
+					const visBase::PolygonSelection*);
+	bool			updateMarkerAtSection(const SurveyObject*,int);
+	void			updateLineAtSection();
 
-    bool			removeSelections(TaskRunner*) override;
-    bool			draggerNormal() const override;
-    void			setDraggerNormal(const Coord3&) override;
+	bool			removeSelections(TaskRunner*) override;
+	bool			draggerNormal() const override;
+	void			setDraggerNormal(const Coord3&) override;
 
-    RefMan<visBase::MarkerSet>	markerset_;
-    bool			needline_	= false;
+	RefMan<visBase::MarkerSet>	markerset_;
+	bool			needline_	= false;
 
-    RefMan<visBase::RandomPos2Body> bodydisplay_;
-    bool			shoulddisplaybody_	= false;
-    RefMan<visBase::Dragger>	dragger_;
-    int				draggeridx_	= -1;
-    bool			showdragger_	= false;
+	RefMan<visBase::RandomPos2Body> bodydisplay_;
+	bool			shoulddisplaybody_	= false;
+	RefMan<visBase::Dragger>	dragger_;
+	int				draggeridx_	= -1;
+	bool			showdragger_	= false;
 
-    static const char*		sKeyNrPicks();
+	static const char*		sKeyNrPicks();
     static const char*		sKeyPickPrefix();
     static const char*		sKeyDisplayBody();
 

--- a/include/visSurvey/vispicksetdisplay.h
+++ b/include/visSurvey/vispicksetdisplay.h
@@ -76,15 +76,15 @@ public:
     bool			usePar(const IOPar&) override;
 
 protected:
-				~PickSetDisplay();
+			~PickSetDisplay();
 
-    void			setPosition(int loc,const Pick::Location&);
-    void			setPosition(int idx,const Pick::Location&,
-					    bool add=false) override;
-    Coord3			getPosition(int loc) const;
-    void			removePosition(int idx) override;
-    void			removeAll() override;
-    void			redrawMultiSets() override;
+	void			setPosition(int loc,const Pick::Location&);
+	void			setPosition(int idx,const Pick::Location&,
+					bool add=false) override;
+	Coord3			getPosition(int loc) const;
+	void			removePosition(int idx) override;
+	void			removeAll() override;
+	void			redrawMultiSets() override;
 
     void			setPolylinePos(int,const Coord3&);
     void			removePolylinePos(int);

--- a/include/visSurvey/vispolygonbodydisplay.h
+++ b/include/visSurvey/vispolygonbodydisplay.h
@@ -93,8 +93,6 @@ public:
     void			setMarkerStyle(const MarkerStyle3D&) override;
     const MarkerStyle3D*	markerStyle() const override;
 
-    bool			turnOn(bool) override;
-
     void			fillPar(IOPar&) const override;
     bool			usePar(const IOPar&) override;
 
@@ -167,6 +165,10 @@ protected:
     bool				iserasing_		= false;
     Coord3				erasestartpos_;
     Coord3				eraseendpos_;
+
+    // For drag mode (sowing) - track mode
+    bool				isdragging_		= false;
+    int				draginsertmode_		= 0; // 0=append, 1=prepend
 
     OD::Color				nontexturecol_;
 

--- a/include/visSurvey/vispolygonbodydisplay.h
+++ b/include/visSurvey/vispolygonbodydisplay.h
@@ -77,9 +77,10 @@ public:
     bool			setEMID(const EM::ObjectID&);
     EM::ObjectID		getEMID() const;
 
-    void			touchAll(bool,bool updatemarker=false);
-    const EM::PolygonBody*	getEMPolygonBody() const
-				{ return empolygonsurf_.ptr(); }
+	void			touchAll(bool,bool updatemarker=false);
+	void			closePolygon();
+	const EM::PolygonBody*	getEMPolygonBody() const
+			{ return empolygonsurf_.ptr(); }
     EM::PolygonBody*		getEMPolygonBody()
 				{ return empolygonsurf_.ptr(); }
     bool			canRemoveSelection() const override
@@ -114,6 +115,9 @@ protected:
     bool			isPicking() const override;
     void			mouseCB(CallBacker*);
     void			emChangeCB(CallBacker*);
+    void			sowingFinishedCB(CallBacker*);
+    void			eraseKnotsNearPosition(const Coord3& pos);
+    void			eraseKnotsBetweenDragPositions();
 
     void			updateNearestPolygonMarker();
     void			setNewIntersectingPolygon(const Coord3& normal,
@@ -145,14 +149,22 @@ protected:
 
     RefMan<visBase::PolyLine3D>		nearestpolygonmarker_;
     int					nearestpolygon_		= mUdf(int);
+    RefMan<visBase::PolyLine>		openpolygonline_;
 
     RefMan<EM::PolygonBody>		empolygonsurf_;
     RefMan<MPE::PolygonBodyEditor>	polygonsurfeditor_;
+
+    bool				polygonclosed_		= false;
     RefMan<MPEEditor>			viseditor_;
 
     Coord3				mousepos_;
 
     bool				showmanipulator_	= false;
+
+    // For Ctrl+Drag deletion
+    bool				iserasing_		= false;
+    Coord3				erasestartpos_;
+    Coord3				eraseendpos_;
 
     OD::Color				nontexturecol_;
 

--- a/include/visSurvey/vispolygonbodydisplay.h
+++ b/include/visSurvey/vispolygonbodydisplay.h
@@ -93,6 +93,8 @@ public:
     void			setMarkerStyle(const MarkerStyle3D&) override;
     const MarkerStyle3D*	markerStyle() const override;
 
+    bool			turnOn(bool) override;
+
     void			fillPar(IOPar&) const override;
     bool			usePar(const IOPar&) override;
 

--- a/src/General/pickset.cc
+++ b/src/General/pickset.cc
@@ -47,6 +47,25 @@ static MarkerStyle3D		defMarkerStyle3D()
     return MarkerStyle3D( defMarkerStyle(), defPixSz(), defcolor() );
 }
 
+// Polygon-specific defaults (matching PolygonBodyDisplay)
+static OD::Color		defPolygonColor()    { return OD::Color(0, 255, 0); }  // Green
+static int			defPolygonPixSz()    { return 5; }
+static MarkerStyle3D::Type	defPolygonMarkerStyle() { return MarkerStyle3D::Cube; }
+static OD::LineStyle		defPolygonLineStyle()
+{
+    return OD::LineStyle( OD::LineStyle::Solid, 5, OD::Color::Black() );
+}
+
+static MarkerStyle2D		defPolygonMarkerStyle2D()
+{
+    return MarkerStyle2D( MarkerStyle2D::Square, defPolygonPixSz(), defPolygonColor() );
+}
+
+static MarkerStyle3D		defPolygonMarkerStyle3D()
+{
+    return MarkerStyle3D( defPolygonMarkerStyle(), defPolygonPixSz(), defPolygonColor() );
+}
+
 
 int Pick::Set::getSizeThreshold()
 {
@@ -1382,26 +1401,28 @@ void Set::setDefaultDispPars( bool ispolygon )
 
 void Set::setDefaultDispPars2D( bool ispolygon )
 {
-    disp2d_.markerstyle_ = defMarkerStyle2D();
-    if ( !ispolygon )
+	disp2d_.markerstyle_ = ispolygon ? defPolygonMarkerStyle2D() 
+									 : defMarkerStyle2D();
+	if ( !ispolygon )
 	return;
 
-    disp2d_.polyDisp()->fillcolor_ = defcolor();
-    disp2d_.polyDisp()->linestyle_ = defLineStyle();
-    if ( disp2d_.polyDisp()->connect_==Connection::None )
+	disp2d_.polyDisp()->fillcolor_ = defPolygonColor();
+	disp2d_.polyDisp()->linestyle_ = defPolygonLineStyle();
+	if ( disp2d_.polyDisp()->connect_==Connection::None )
 	disp2d_.polyDisp()->connect_ = Connection::Close;
 }
 
 
 void Set::setDefaultDispPars3D( bool ispolygon )
 {
-    disp3d_.markerstyle_ = defMarkerStyle3D();
-    if ( !ispolygon )
+	disp3d_.markerstyle_ = ispolygon ? defPolygonMarkerStyle3D() 
+									 : defMarkerStyle3D();
+	if ( !ispolygon )
 	return;
 
-    disp3d_.polyDisp()->fillcolor_ = defcolor();
-    disp3d_.polyDisp()->linestyle_ = defLineStyle();
-    if ( disp3d_.polyDisp()->connect_==Connection::None )
+	disp3d_.polyDisp()->fillcolor_ = defPolygonColor();
+	disp3d_.polyDisp()->linestyle_ = defPolygonLineStyle();
+	if ( disp3d_.polyDisp()->connect_==Connection::None )
 	disp3d_.polyDisp()->connect_ = Connection::Close;
 }
 

--- a/src/uiIo/uicreatepicks.cc
+++ b/src/uiIo/uicreatepicks.cc
@@ -74,42 +74,45 @@ uiCreatePicks::~uiCreatePicks()
 
 void uiCreatePicks::addStdFields( uiObject* lastobject )
 {
-    outfld_ = uiPointSetPolygonSel::create( this, false, aspolygon_ );
+	outfld_ = uiPointSetPolygonSel::create( this, false, aspolygon_ );
 
-    colsel_ = new uiColorInput( this,
-				uiColorInput::Setup(OD::getRandStdDrawColor())
+	// Use green for polygons, random color for point sets
+	const OD::Color defcolor = aspolygon_ ? OD::Color(0,255,0) 
+					  : OD::getRandStdDrawColor();
+	colsel_ = new uiColorInput( this,
+				uiColorInput::Setup(defcolor)
 						.lbltxt(uiStrings::sColor()) );
-    colsel_->attach( alignedBelow, outfld_ );
-    if ( lastobject )
+	colsel_->attach( alignedBelow, outfld_ );
+	if ( lastobject )
 	outfld_->attach( alignedBelow, lastobject );
 
-    if ( iszvalreq_ )
-    {
-        float zval = SI().zRange(true).start_;
+	if ( iszvalreq_ )
+	{
+		float zval = SI().zRange(true).start_;
 	zval *= SI().zDomain().userFactor();
 	const uiString lbl(
 		tr("Z value for Points %1").arg(SI().getUiZUnitString()) );
 	zvalfld_ = new uiGenInput( this, lbl, FloatInpSpec(zval) );
 	zvalfld_->attach( alignedBelow, colsel_ );
-    }
+	}
 }
 
 
 RefMan<Pick::Set> uiCreatePicks::getPickSet() const
 {
-    RefMan<Pick::Set> ret = new Pick::Set( name_, aspolygon_ );
-    ret->disp3d().markerstyle_.color_ = colsel_->color();
-    ret->disp2d().markerstyle_.color_ = colsel_->color();
-    if ( !ret->isPolygon() )
+	RefMan<Pick::Set> ret = new Pick::Set( name_, aspolygon_ );
+	ret->disp3d().markerstyle_.color_ = colsel_->color();
+	ret->disp2d().markerstyle_.color_ = colsel_->color();
+	if ( !ret->isPolygon() )
 	return ret;
 
-    if ( ret->disp3d().polyDisp() )
+	if ( ret->disp3d().polyDisp() )
 	ret->disp3d().polyDisp()->connect_ = Pick::Set::Connection::Open;
 
-    if ( ret->disp2d().polyDisp() )
+	if ( ret->disp2d().polyDisp() )
 	ret->disp2d().polyDisp()->connect_ = Pick::Set::Connection::Open;
 
-    return ret;
+	return ret;
 }
 
 

--- a/src/uiODMain/uiodbodydisplaytreeitem.cc
+++ b/src/uiODMain/uiodbodydisplaytreeitem.cc
@@ -98,7 +98,11 @@ bool uiODBodyDisplayParentTreeItem::showSubMenu()
 	plg->setNewName();
 	plg->setFullyLoaded( true );
 	addChild( new uiODBodyDisplayTreeItem( plg->id() ), false );
-    }
+
+	// Switch to Interact mode for polygon editing
+	ODMainWin()->applMgr().visServer()->setWorkMode( 
+		uiVisPartServer::Interactive, true );
+	}
     else if ( mnuid==2 || mnuid==3 )
     {
 	MouseCursorChanger mcc( MouseCursor::Wait );
@@ -197,23 +201,24 @@ uiTreeItem* uiODBodyDisplayTreeItemFactory::createForVis( const VisID& visid,
 
 
 uiODBodyDisplayTreeItem::uiODBodyDisplayTreeItem()
-    : uiODDisplayTreeItem()
-    , savemnuitem_(uiStrings::sSave())
-    , saveasmnuitem_(uiStrings::sSaveAs())
-    , displaybodymnuitem_(uiStrings::sGeobody())
-    , displaypolygonmnuitem_(uiODBodyDisplayTreeItem::sPickedPolygons())
-    , displayintersectionmnuitem_(uiStrings::sOnlyAtSections())
-    , singlecolormnuitem_(uiStrings::sUseSingleColor())
-    , volcalmnuitem_(m3Dots(uiODBodyDisplayTreeItem::sCalcVolume()))
+	: uiODDisplayTreeItem()
+	, savemnuitem_(uiStrings::sSave())
+	, saveasmnuitem_(uiStrings::sSaveAs())
+	, displaybodymnuitem_(uiStrings::sGeobody())
+	, displaypolygonmnuitem_(uiODBodyDisplayTreeItem::sPickedPolygons())
+	, displayintersectionmnuitem_(uiStrings::sOnlyAtSections())
+	, singlecolormnuitem_(uiStrings::sUseSingleColor())
+	, volcalmnuitem_(m3Dots(uiODBodyDisplayTreeItem::sCalcVolume()))
+	, closepolygonmnuitem_(tr("Close Polygon"))
 {
-    displaybodymnuitem_.checkable = true;
-    displaypolygonmnuitem_.checkable = true;
-    displayintersectionmnuitem_.checkable = true;
-    singlecolormnuitem_.checkable = true;
-    savemnuitem_.iconfnm = "save";
-    saveasmnuitem_.iconfnm = "saveas";
-    mAttachCB( NotSavedPrompter::NSP().promptSaving,
-	       uiODBodyDisplayTreeItem::askSaveCB );
+	displaybodymnuitem_.checkable = true;
+	displaypolygonmnuitem_.checkable = true;
+	displayintersectionmnuitem_.checkable = true;
+	singlecolormnuitem_.checkable = true;
+	savemnuitem_.iconfnm = "save";
+	saveasmnuitem_.iconfnm = "saveas";
+	mAttachCB( NotSavedPrompter::NSP().promptSaving,
+		   uiODBodyDisplayTreeItem::askSaveCB );
 }
 
 
@@ -269,13 +274,16 @@ bool uiODBodyDisplayTreeItem::init()
 	mDynamicCastGet( EM::RandomPosBody*, emrpb, object );
 	if ( emplg )
 	{
-	    RefMan<visSurvey::PolygonBodyDisplay> plg =
-					    new visSurvey::PolygonBodyDisplay;
-	    if ( !plg->setEMID(emid_) )
+		RefMan<visSurvey::PolygonBodyDisplay> plg =
+						new visSurvey::PolygonBodyDisplay;
+		if ( !plg->setEMID(emid_) )
 		return false;
 
-	    displayid_ = plg->id();
-	    visserv_->addObject( plg.ptr(), sceneID(), true);
+		displayid_ = plg->id();
+		visserv_->addObject( plg.ptr(), sceneID(), true);
+
+		// Switch to Interact mode for polygon editing
+		visserv_->setWorkMode( uiVisPartServer::Interactive, true );
 	}
 	else if ( emmcs )
 	{
@@ -461,17 +469,20 @@ void uiODBodyDisplayTreeItem::createMenu( MenuHandler* menu, bool istb )
     const bool enablesave = applMgr()->EMServer()->isChanged(emid_) &&
 			    applMgr()->EMServer()->isFullyLoaded(emid_);
 
-    ConstRefMan<visSurvey::PolygonBodyDisplay> plg = getPBDisplay();
-    if ( plg )
-    {
+	ConstRefMan<visSurvey::PolygonBodyDisplay> plg = getPBDisplay();
+	if ( plg )
+	{
 	mAddMenuItem( &displaymnuitem_, &displaybodymnuitem_, true,
-		      plg->isBodyDisplayed() );
+			  plg->isBodyDisplayed() );
 	mAddMenuItem( &displaymnuitem_, &displaypolygonmnuitem_, true,
-		      plg->arePolygonsDisplayed() );
+			  plg->arePolygonsDisplayed() );
 	mAddMenuItem( &displaymnuitem_, &displayintersectionmnuitem_, true,
-		      plg->displayedOnlyAtSections() );
+			  plg->displayedOnlyAtSections() );
 	mAddMenuItem( menu, &displaymnuitem_, true, true );
-    }
+
+	// Add "Close Polygon" menu item - always show for polygon bodies
+	mAddMenuItem( menu, &closepolygonmnuitem_, true, false );
+	}
 
     ConstRefMan<visSurvey::MarchingCubesDisplay> mcd = getMCDisplay();
     if ( mcd )
@@ -572,12 +583,19 @@ void uiODBodyDisplayTreeItem::handleMenuCB( CallBacker* cb )
 	plg->display( polygondisplay, bodydisplayed );
 	plg->setOnlyAtSectionsDisplay( !polygondisplay && !bodydisplayed );
     }
-    else if ( mnuid==displayintersectionmnuitem_.id )
-    {
+	else if ( mnuid==displayintersectionmnuitem_.id )
+	{
 	const bool intersectdisplay = !displayintersectionmnuitem_.checked;
 	setOnlyAtSectionsDisplay( intersectdisplay );
-    }
-    else if ( mnuid==singlecolormnuitem_.id )
+	}
+	else if ( mnuid==closepolygonmnuitem_.id )
+	{
+	// Close Polygon action
+	RefMan<visSurvey::PolygonBodyDisplay> plg = getPBDisplay();
+	if ( plg )
+		plg->closePolygon();
+	}
+	else if ( mnuid==singlecolormnuitem_.id )
     {
 	mcd->useTexture( !mcd->showsTexture(), true );
     }

--- a/src/visSurvey/vislocationdisplay.cc
+++ b/src/visSurvey/vislocationdisplay.cc
@@ -17,6 +17,7 @@ ________________________________________________________________________
 #include "survgeom2d.h"
 #include "uistrings.h"
 #include "vismaterial.h"
+#include "vispicksetdisplay.h"
 #include "visplanedatadisplay.h"
 #include "visrandomtrackdisplay.h"
 #include "visseis2ddisplay.h"
@@ -226,18 +227,104 @@ bool LocationDisplay::displayedOnlyAtSections() const
 
 void LocationDisplay::pickCB( CallBacker* cb )
 {
-    if ( painter_ && painter_->isActive() )
+	if ( painter_ && painter_->isActive() )
 	return;
 
-    if ( !set_ || set_->isReadOnly() )
+	if ( !set_ || set_->isReadOnly() )
 	return;
 
-    if ( !isSelected() || !isOn() || isLocked() ) return;
+	if ( !isSelected() || !isOn() || isLocked() ) return;
 
-    mCBCapsuleUnpack( const visBase::EventInfo&, eventinfo, cb );
-    ctrldown_ = OD::ctrlKeyboardButton( eventinfo.buttonstate_ );
+	mCBCapsuleUnpack( const visBase::EventInfo&, eventinfo, cb );
+	ctrldown_ = OD::ctrlKeyboardButton( eventinfo.buttonstate_ );
 
-    if ( eventinfo.dragging )
+	// Handle Ctrl+Drag for polygon erasing
+	const bool ispolygon = set_->isPolygon();
+	const bool iserasemode = ispolygon && OD::ctrlKeyboardButton(eventinfo.buttonstate_);
+
+	mDynamicCastGet(visSurvey::PickSetDisplay*,picksetdisp,this);
+
+	if ( iserasemode && picksetdisp )
+	{
+	// Handle Ctrl+Drag deletion - record start/end positions
+	if ( eventinfo.type == visBase::MouseClick && eventinfo.pressed )
+	{
+		// Start of Ctrl+Drag - reset state first
+		picksetdisp->iserasing_ = false;
+		picksetdisp->erasestartpos_ = Coord3::udf();
+		picksetdisp->eraseendpos_ = Coord3::udf();
+
+		// Now record start position
+		Coord3 pos, normal;
+		if ( getPickSurface(eventinfo, pos, normal) )
+		{
+		picksetdisp->iserasing_ = true;
+		picksetdisp->erasestartpos_ = pos;
+		picksetdisp->eraseendpos_ = pos;
+		eventcatcher_->setHandled();
+		}
+		return;
+	}
+	else if ( eventinfo.type == visBase::MouseMovement && eventinfo.pressed )
+	{
+		// During drag - update end position
+		if ( picksetdisp->iserasing_ )
+		{
+		Coord3 pos, normal;
+		if ( getPickSurface(eventinfo, pos, normal) )
+		{
+			picksetdisp->eraseendpos_ = pos;
+			eventcatcher_->setHandled();
+		}
+		}
+		return;
+	}
+	else if ( eventinfo.type == visBase::MouseClick && !eventinfo.pressed )
+	{
+		// End of Ctrl+Drag - check if it was a drag or just a click
+		if ( picksetdisp->iserasing_ )
+		{
+		Coord3 pos, normal;
+		if ( getPickSurface(eventinfo, pos, normal) )
+		{
+			picksetdisp->eraseendpos_ = pos;
+
+			// Check if there was actual movement (drag) vs just a click
+			const double dx = fabs(picksetdisp->eraseendpos_.x_ - picksetdisp->erasestartpos_.x_);
+			const double dy = fabs(picksetdisp->eraseendpos_.y_ - picksetdisp->erasestartpos_.y_);
+			const double dragdist = sqrt(dx*dx + dy*dy);
+			const double clickthreshold = 10.0; // Minimum distance to be considered a drag
+
+			if ( dragdist > clickthreshold )
+			{
+			// It was a drag - delete all points in range
+			picksetdisp->erasePointsBetweenDragPositions();
+			}
+			else
+			{
+			// It was just a click - delete single nearest point
+			picksetdisp->erasePointsNearPosition( pos );
+			}
+		}
+
+		// Always reset state after release
+		picksetdisp->iserasing_ = false;
+		picksetdisp->erasestartpos_ = Coord3::udf();
+		picksetdisp->eraseendpos_ = Coord3::udf();
+		eventcatcher_->setHandled();
+		}
+		return;
+	}
+	}
+	else if ( picksetdisp && picksetdisp->iserasing_ )
+	{
+	// Not in erase mode anymore - reset state
+	picksetdisp->iserasing_ = false;
+	picksetdisp->erasestartpos_ = Coord3::udf();
+	picksetdisp->eraseendpos_ = Coord3::udf();
+	}
+
+	if ( eventinfo.dragging )
 	updateDragger();
 
     VisID eventid;
@@ -726,25 +813,28 @@ bool LocationDisplay::isPainting() const
 }
 
 bool LocationDisplay::addPick( const Coord3& pos, const Sphere& dir,
-			       bool notif )
+				   bool notif )
 {
-    if ( selectionmodel_ )
+	if ( selectionmodel_ )
 	return false;
 
-    mDefineStaticLocalObject( TypeSet<Coord3>, sowinghistory, );
+	mDefineStaticLocalObject( TypeSet<Coord3>, sowinghistory, );
 
-    int locidx = -1;
-    bool insertpick = false;
-    const bool isclosedpoly = set_->isPolygon() && set_->disp3d().polyDisp() &&
-	    set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close;
-    if ( isclosedpoly )
-    {
+	int locidx = -1;
+	bool insertpick = false;
+	const bool isclosedpoly = set_->isPolygon() && set_->disp3d().polyDisp() &&
+		set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close;
+	const bool isopenpoly = set_->isPolygon() && set_->disp3d().polyDisp() &&
+		set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Open;
+
+	if ( isclosedpoly )
+	{
 	sower_->alternateSowingOrder( true );
 	Coord3 displaypos = world2Display( pos );
 	if ( sower_->mode() == Sower::FirstSowing )
 	{
-	    displaypos = sower_->pivotPos();
-	    sowinghistory.erase();
+		displaypos = sower_->pivotPos();
+		sowinghistory.erase();
 	}
 
 	float mindist = mUdf(float);
@@ -772,8 +862,73 @@ bool LocationDisplay::addPick( const Coord3& pos, const Sphere& dir,
 
 	sowinghistory.insert( 0, pos );
 	sowinghistory.removeSingle( 2 );
-    }
-    else
+	}
+	else if ( isopenpoly && set_->size() > 0 )
+	{
+	// Smart insertion for open polygons:
+	// 1) Click near first point: prepend (insert at 0)
+	// 2) Click near last point: append
+	// 3) Click near midpoint: insert between nearest neighbors
+	// 4) Drag from midpoint: do nothing (handled by sower logic)
+
+	sower_->alternateSowingOrder( false );
+
+	const int nrpts = set_->size();
+	const Coord3 displaypos = world2Display( pos );
+
+	// Find nearest existing point
+	int nearestidx = -1;
+	float mindist = mUdf(float);
+	for ( int idx=0; idx<nrpts; idx++ )
+	{
+		const Coord3 ptpos = world2Display( set_->getPos(idx) );
+		const float dist = sCast(float,ptpos.distTo( displaypos ));
+		if ( mIsUdf(mindist) || dist < mindist )
+		{
+		mindist = dist;
+		nearestidx = idx;
+		}
+	}
+
+	if ( nearestidx == 0 )
+	{
+		// Near first point - prepend
+		locidx = 0;
+		insertpick = true;
+	}
+	else if ( nearestidx == nrpts - 1 )
+	{
+		// Near last point - append (will be handled below with insertpick=false)
+		insertpick = false;
+	}
+	else
+	{
+		// Near midpoint - find which segment to insert into
+		const Coord3 nearpt = world2Display( set_->getPos(nearestidx) );
+		const Coord3 prevpt = world2Display( set_->getPos(nearestidx-1) );
+		const Coord3 nextpt = world2Display( set_->getPos(nearestidx+1) );
+
+		const float dist_to_prev_seg = findDistance( prevpt, nearpt, displaypos );
+		const float dist_to_next_seg = findDistance( nearpt, nextpt, displaypos );
+
+		if ( !mIsUdf(dist_to_prev_seg) && !mIsUdf(dist_to_next_seg) )
+		{
+		if ( dist_to_prev_seg < dist_to_next_seg )
+		{
+			// Closer to segment before nearest point
+			locidx = nearestidx;
+			insertpick = true;
+		}
+		else
+		{
+			// Closer to segment after nearest point
+			locidx = nearestidx + 1;
+			insertpick = true;
+		}
+		}
+	}
+	}
+	else
 	sower_->alternateSowingOrder( false );
 
     Pick::Location newloc( pos, dir );

--- a/src/visSurvey/vislocationdisplay.cc
+++ b/src/visSurvey/vislocationdisplay.cc
@@ -254,9 +254,10 @@ void LocationDisplay::pickCB( CallBacker* cb )
 		picksetdisp->erasestartpos_ = Coord3::udf();
 		picksetdisp->eraseendpos_ = Coord3::udf();
 
-		// Now record start position
-		Coord3 pos, normal;
-		if ( getPickSurface(eventinfo, pos, normal) )
+		// Now record start position - use displaypickedpos directly
+		Coord3 pos = display2World( eventinfo.displaypickedpos );
+
+		if ( pos.isDefined() )
 		{
 		picksetdisp->iserasing_ = true;
 		picksetdisp->erasestartpos_ = pos;
@@ -270,8 +271,9 @@ void LocationDisplay::pickCB( CallBacker* cb )
 		// During drag - update end position
 		if ( picksetdisp->iserasing_ )
 		{
-		Coord3 pos, normal;
-		if ( getPickSurface(eventinfo, pos, normal) )
+		Coord3 pos = display2World( eventinfo.displaypickedpos );
+
+		if ( pos.isDefined() )
 		{
 			picksetdisp->eraseendpos_ = pos;
 			eventcatcher_->setHandled();
@@ -284,8 +286,9 @@ void LocationDisplay::pickCB( CallBacker* cb )
 		// End of Ctrl+Drag - check if it was a drag or just a click
 		if ( picksetdisp->iserasing_ )
 		{
-		Coord3 pos, normal;
-		if ( getPickSurface(eventinfo, pos, normal) )
+		Coord3 pos = display2World( eventinfo.displaypickedpos );
+
+		if ( pos.isDefined() )
 		{
 			picksetdisp->eraseendpos_ = pos;
 

--- a/src/visSurvey/vispicksetdisplay.cc
+++ b/src/visSurvey/vispicksetdisplay.cc
@@ -163,6 +163,10 @@ void PickSetDisplay::setChg( CallBacker* cb )
 {
     LocationDisplay::setChg( cb );
     setBodyDisplay();
+
+    // For polygons, ensure smooth curve is drawn after set changes
+    if ( set_ && set_->isPolygon() && set_->nrSets() <= 1 )
+    redrawLine();
 }
 
 
@@ -250,44 +254,44 @@ Coord3 PickSetDisplay::getPosition( int loc ) const
 
 void PickSetDisplay::setPolylinePos( int idx, const Coord3& pos )
 {
-    if ( !polylines_ )
+	if ( !polylines_ )
 	createLine();
 
-    if ( set_->nrSets() > 1 )
+	if ( set_->nrSets() > 1 )
 	return;
 
-    const bool doredraw = set_->isPolygon() && set_->disp3d().polyDisp() &&
-	    set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close;
-    if ( doredraw )
-    {
+	const bool doredraw = set_->isPolygon() && set_->disp3d().polyDisp() &&
+		set_->disp3d().polyDisp()->connect_!=Pick::Set::Connection::None;
+	if ( doredraw )
+	{
 	redrawLine();
 	return;
-    }
+	}
 
-    polylines_->setPoint( idx, pos );
-    polylines_->dirtyCoordinates();
+	polylines_->setPoint( idx, pos );
+	polylines_->dirtyCoordinates();
 }
 
 
 void PickSetDisplay::removePosition( int idx )
 {
-    mCheckReadyOnly( set_ )
+	mCheckReadyOnly( set_ )
 
-    const bool doredraw = set_->isPolygon() && set_->disp3d().polyDisp() &&
-	    set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close;
-    if ( doredraw )
-    {
+	const bool doredraw = set_->isPolygon() && set_->disp3d().polyDisp() &&
+		set_->disp3d().polyDisp()->connect_!=Pick::Set::Connection::None;
+	if ( doredraw )
+	{
 	redrawAll( idx );
 	return;
-    }
+	}
 
-    if ( !markerset_ || idx>=markerset_->size() )
+	if ( !markerset_ || idx>=markerset_->size() )
 	return;
 
-    markerset_->removeMarker( idx );
-    removePolylinePos( idx );
+	markerset_->removeMarker( idx );
+	removePolylinePos( idx );
 
-    dragger_->turnOn( false );
+	dragger_->turnOn( false );
 }
 
 
@@ -382,24 +386,24 @@ void PickSetDisplay::redrawMultiSets()
 
 void PickSetDisplay::redrawAll( int drageridx )
 {
-    if ( !markerset_ )
+	if ( !markerset_ )
 	return;
 
-    if ( !polylines_ && needLine() )
+	if ( !polylines_ && needLine() )
 	createLine();
 
-    markerset_->clearMarkers();
-    for ( int idx=0; idx<set_->size(); idx++ )
-    {
+	markerset_->clearMarkers();
+	for ( int idx=0; idx<set_->size(); idx++ )
+	{
 	Coord3 pos = set_->getPos( idx );
 	if ( datatransform_ )
-            pos.z_ = datatransform_->transform( pos );
-        if ( !mIsUdf(pos.z_) )
-	    markerset_->addPos( pos );
-    }
+			pos.z_ = datatransform_->transform( pos );
+		if ( !mIsUdf(pos.z_) )
+		markerset_->addPos( pos );
+	}
 
-    markerset_->forceRedraw( true );
-    redrawLine();
+	markerset_->forceRedraw( true );
+	redrawLine();
 }
 
 
@@ -439,33 +443,123 @@ void PickSetDisplay::createLine()
 
 void PickSetDisplay::redrawLine()
 {
-    if ( !polylines_ || !set_ )
+	if ( !polylines_ || !set_ )
 	return;
 
-    const bool ispoly = set_->isPolygon() && set_->disp3d().polyDisp();
-    polylines_->setLineStyle( ispoly ? set_->disp3d().polyDisp()->linestyle_
-				     : OD::LineStyle() );
+	const bool ispoly = set_->isPolygon() && set_->disp3d().polyDisp();
+	polylines_->setLineStyle( ispoly ? set_->disp3d().polyDisp()->linestyle_
+					 : OD::LineStyle() );
 
-    if ( set_->nrSets() > 1 )
+	if ( set_->nrSets() > 1 )
 	return;
 
-    polylines_->removeAllPoints();
+	polylines_->removeAllPoints();
 
-    int idx=0;
-    for ( ; idx<set_->size(); idx++ )
-    {
+	// Collect all valid knot positions
+	TypeSet<Coord3> rawknots;
+	for ( int idx=0; idx<set_->size(); idx++ )
+	{
 	Coord3 pos = set_->getPos( idx );
 	if ( datatransform_ )
-            pos.z_ = datatransform_->transform( pos );
-        if ( !mIsUdf(pos.z_) )
-	    polylines_->addPoint( pos );
-    }
+		pos.z_ = datatransform_->transform( pos );
+	if ( !mIsUdf(pos.z_) )
+		rawknots += pos;
+	}
 
-    if ( idx && ispoly &&
-	 set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close )
-	polylines_->setPoint( idx, polylines_->getPoint(0) );
+	const int nrknots = rawknots.size();
+	if ( nrknots == 0 )
+	return;
 
-    polylines_->dirtyCoordinates();
+	// For polygons with >= 2 points, apply Catmull-Rom spline interpolation
+	if ( ispoly && nrknots >= 2 )
+	{
+	const int interpsteps = 10; // Points per segment for smooth curve
+
+	// Add interpolated points between each pair of knots
+	for ( int kidx=0; kidx<nrknots-1; kidx++ )
+	{
+		const Coord3& p0 = rawknots[kidx];
+		const Coord3& p1 = rawknots[kidx+1];
+
+		// Get neighboring points for polynomial interpolation
+		const Coord3 pm1 = kidx > 0 ? rawknots[kidx-1] : p0;
+		const Coord3 p2 = kidx < nrknots-2 ? rawknots[kidx+2] : p1;
+
+		// Interpolate between p0 and p1 using 4-point Catmull-Rom spline
+		for ( int step=0; step<interpsteps; step++ )
+		{
+		const float t = float(step) / float(interpsteps);
+		const float t2 = t * t;
+		const float t3 = t2 * t;
+
+		Coord3 interp;
+		interp.x_ = 0.5f * ((2.0f*p0.x_) +
+			(-pm1.x_ + p1.x_) * t +
+			(2.0f*pm1.x_ - 5.0f*p0.x_ + 4.0f*p1.x_ - p2.x_) * t2 +
+			(-pm1.x_ + 3.0f*p0.x_ - 3.0f*p1.x_ + p2.x_) * t3);
+		interp.y_ = 0.5f * ((2.0f*p0.y_) +
+			(-pm1.y_ + p1.y_) * t +
+			(2.0f*pm1.y_ - 5.0f*p0.y_ + 4.0f*p1.y_ - p2.y_) * t2 +
+			(-pm1.y_ + 3.0f*p0.y_ - 3.0f*p1.y_ + p2.y_) * t3);
+		interp.z_ = 0.5f * ((2.0f*p0.z_) +
+			(-pm1.z_ + p1.z_) * t +
+			(2.0f*pm1.z_ - 5.0f*p0.z_ + 4.0f*p1.z_ - p2.z_) * t2 +
+			(-pm1.z_ + 3.0f*p0.z_ - 3.0f*p1.z_ + p2.z_) * t3);
+
+		polylines_->addPoint( interp );
+		}
+	}
+
+	// Add the final knot
+	polylines_->addPoint( rawknots[nrknots-1] );
+
+	// If closed polygon, interpolate from last knot back to first
+	const bool isclosed = set_->disp3d().polyDisp()->connect_ ==
+				  Pick::Set::Connection::Close;
+	if ( isclosed && nrknots > 2 )
+	{
+		const Coord3& p0 = rawknots[nrknots-1];
+		const Coord3& p1 = rawknots[0];
+		const Coord3& pm1 = rawknots[nrknots-2];
+		const Coord3& p2 = rawknots[1];
+
+		for ( int step=1; step<=interpsteps; step++ )
+		{
+		const float t = float(step) / float(interpsteps);
+		const float t2 = t * t;
+		const float t3 = t2 * t;
+
+		Coord3 interp;
+		interp.x_ = 0.5f * ((2.0f*p0.x_) +
+			(-pm1.x_ + p1.x_) * t +
+			(2.0f*pm1.x_ - 5.0f*p0.x_ + 4.0f*p1.x_ - p2.x_) * t2 +
+			(-pm1.x_ + 3.0f*p0.x_ - 3.0f*p1.x_ + p2.x_) * t3);
+		interp.y_ = 0.5f * ((2.0f*p0.y_) +
+			(-pm1.y_ + p1.y_) * t +
+			(2.0f*pm1.y_ - 5.0f*p0.y_ + 4.0f*p1.y_ - p2.y_) * t2 +
+			(-pm1.y_ + 3.0f*p0.y_ - 3.0f*p1.y_ + p2.y_) * t3);
+		interp.z_ = 0.5f * ((2.0f*p0.z_) +
+			(-pm1.z_ + p1.z_) * t +
+			(2.0f*pm1.z_ - 5.0f*p0.z_ + 4.0f*p1.z_ - p2.z_) * t2 +
+			(-pm1.z_ + 3.0f*p0.z_ - 3.0f*p1.z_ + p2.z_) * t3);
+
+		polylines_->addPoint( interp );
+		}
+	}
+	}
+	else
+	{
+	// For non-polygons or single point, use linear interpolation
+	for ( int idx=0; idx<nrknots; idx++ )
+		polylines_->addPoint( rawknots[idx] );
+
+	// Close the polygon if needed (for polygons with < 2 points)
+	if ( ispoly && nrknots > 0 &&
+		 set_->disp3d().polyDisp()->connect_==Pick::Set::Connection::Close )
+		polylines_->addPoint( rawknots[0] );
+	}
+
+	polylines_->dirtyCoordinates();
 }
 
 

--- a/src/visSurvey/vispicksetdisplay.cc
+++ b/src/visSurvey/vispicksetdisplay.cc
@@ -731,12 +731,13 @@ void PickSetDisplay::otherObjectsMoved(
 			const ObjectSet<const SurveyObject>& objs,
 			const VisID& movedid )
 {
-    mCheckReadyOnly(set_)
+	mCheckReadyOnly(set_)
 
-    if ( showall_ && areallshown_ )
+	// If not in "display only at sections" mode and everything is shown, nothing to do
+	if ( !displayonlyatsections_ && areallshown_ )
 	return;
 
-    const bool singleobjectmoved = movedid.isValid() && movedid != id();
+	const bool singleobjectmoved = movedid.isValid() && movedid != id();
     ObjectSet<const SurveyObject> objstouse;
     const SurveyObject* validmovedobj = nullptr;
     for ( int idx=0; idx<objs.size(); idx++ )
@@ -774,20 +775,25 @@ void PickSetDisplay::otherObjectsMoved(
 	}
 
 	if ( validmovedobj == objs[idx] )
-	    validmovedobj = nullptr;
-    }
+		validmovedobj = nullptr;
+	}
 
-    if ( singleobjectmoved && !validmovedobj )
+	// If a single object moved but we didn't find it in the active objects list,
+	// it might have been turned off. In "display only at sections" mode, we still
+	// need to update to hide markers that were on that section.
+	if ( singleobjectmoved && !validmovedobj && !displayonlyatsections_ )
 	return;
 
-    if ( objstouse.isEmpty() && showall_ == areallshown_ )
+	// In "display only at sections" mode, we must process even if objstouse is empty
+	// to hide all markers when no sections are present
+	if ( objstouse.isEmpty() && !displayonlyatsections_ )
 	return;
 
-    for ( int idx=0; idx<markerset_->getCoordinates()->size(); idx++ )
-    {
+	for ( int idx=0; idx<markerset_->getCoordinates()->size(); idx++ )
+	{
 	bool showmarker = false;
-	if ( showall_ )
-	    showmarker = true;
+	if ( !displayonlyatsections_ )
+		showmarker = true;
 	else
 	{
 	    for ( int idy=0; idy<objstouse.size(); idy++ )
@@ -805,11 +811,55 @@ void PickSetDisplay::otherObjectsMoved(
 
 	markerset_->turnMarkerOn( idx, showmarker );
 	markerset_->requestSingleRedraw();
-    }
+	}
 
-    updateLineAtSection();
-    if ( showall_ )
+	updateLineAtSection();
+
+	// Force visual update
+	if ( markerset_ )
+	markerset_->forceRedraw( true );
+
+	if ( !displayonlyatsections_ )
 	areallshown_ = true;
+	else if ( objstouse.isEmpty() )
+	areallshown_ = false;  // No sections visible, so markers should be hidden
+}
+
+
+void PickSetDisplay::setOnlyAtSectionsDisplay( bool yn )
+{
+	if ( displayonlyatsections_ == yn )
+	return;
+
+	displayonlyatsections_ = yn;
+
+	// Update showall_ to match (inverse relationship)
+	showall_ = !yn;
+
+	// Force state to be inconsistent so otherObjectsMoved will definitely process
+	areallshown_ = false;
+
+	// If switching to "show all", immediately turn on all markers and rebuild lines
+	if ( !displayonlyatsections_ && markerset_ )
+	{
+	for ( int idx=0; idx<markerset_->getCoordinates()->size(); idx++ )
+		markerset_->turnMarkerOn( idx, true );
+	markerset_->forceRedraw( true );
+	areallshown_ = true;
+
+	// Also update the polylines to show all connections
+	updateLineAtSection();
+	}
+
+	// Update display via scene notification
+	if ( scene_ )
+	scene_->objectMoved( nullptr );
+}
+
+
+bool PickSetDisplay::displayedOnlyAtSections() const
+{
+	return displayonlyatsections_;
 }
 
 
@@ -828,12 +878,12 @@ bool PickSetDisplay::updateMarkerAtSection( const SurveyObject* obj, int idx )
     if ( scene_ )
 	scene_->getUTM2DisplayTransform()->transform( pos );
 
-    bool onsection = false;
-    if ( !pos.isDefined() )
+	bool onsection = false;
+	if ( !pos.isDefined() )
 	return false;
-    else if ( showall_ )
+	else if ( !displayonlyatsections_ )
 	onsection = true;
-    else
+	else
     {
 	mDynamicCastGet( const EMObjectDisplay*,emobj,obj )
 	if ( emobj && emobj->displayedOnlyAtSections() )
@@ -1105,14 +1155,254 @@ bool PickSetDisplay::removeSelections( TaskRunner* )
 	}
     }
 
-    Pick::Mgr().undo().setUserInteractionEnd(
-			    Pick::Mgr().undo().currentEventID() );
+	Pick::Mgr().undo().setUserInteractionEnd(
+				Pick::Mgr().undo().currentEventID() );
 
-    unSelectAll();
-    if ( changed )
+	unSelectAll();
+	if ( changed )
 	SurveyObject::removeSelections( nullptr );
 
-    return changed;
+	return changed;
+}
+
+
+void PickSetDisplay::erasePointsBetweenDragPositions()
+{
+	if ( !set_ || !erasestartpos_.isDefined() || !eraseendpos_.isDefined() )
+	return;
+
+	const int nrpts = set_->size();
+	if ( nrpts < 2 )
+	return;
+
+	// Get sampling intervals from survey info for normalized distance calculation
+	const double inl_dist = SI().inlDistance();  // Inline spacing in meters
+	const double crl_dist = SI().crlDistance();  // Crossline spacing in meters
+	const double z_step = SI().zStep();          // Z sample rate (e.g., 0.004 for 4ms)
+	const double xy_step = (inl_dist + crl_dist) / 2.0;
+
+	// Find the point nearest to the START position using normalized distances
+	int startknotidx = -1;
+	double mindist_start = 1e30;
+
+	for ( int idx=0; idx<nrpts; idx++ )
+	{
+	const Coord3 ptpos = set_->getPos( idx );
+	if ( !ptpos.isDefined() )
+		continue;
+
+	// Normalize distances by sampling intervals (sample space)
+	const double dx_norm = (ptpos.x_ - erasestartpos_.x_) / xy_step;
+	const double dy_norm = (ptpos.y_ - erasestartpos_.y_) / xy_step;
+	const double dz_norm = (ptpos.z_ - erasestartpos_.z_) / z_step;
+
+	// Compute distance in "sample space"
+	const double dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+
+	if ( dist < mindist_start )
+	{
+		mindist_start = dist;
+		startknotidx = idx;
+	}
+	}
+
+	if ( startknotidx == -1 )
+	return;
+
+	// Determine direction by checking which neighbor is closer to END (also normalized)
+	const int neighbor_forward = (startknotidx + 1 < nrpts) ? startknotidx + 1 : -1;
+	const int neighbor_backward = (startknotidx - 1 >= 0) ? startknotidx - 1 : -1;
+
+	double dist_forward = 1e30;
+	double dist_backward = 1e30;
+
+	if ( neighbor_forward >= 0 )
+	{
+	const Coord3 knotpos = set_->getPos( neighbor_forward );
+	if ( knotpos.isDefined() )
+	{
+		const double dx_norm = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		dist_forward = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+	}
+	}
+
+	if ( neighbor_backward >= 0 )
+	{
+	const Coord3 knotpos = set_->getPos( neighbor_backward );
+	if ( knotpos.isDefined() )
+	{
+		const double dx_norm = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		dist_backward = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+	}
+	}
+
+	// Determine search direction
+	bool search_forward = true;
+	if ( neighbor_forward < 0 && neighbor_backward >= 0 )
+	search_forward = false;
+	else if ( neighbor_backward < 0 && neighbor_forward >= 0 )
+	search_forward = true;
+	else
+	search_forward = (dist_forward <= dist_backward);
+
+	// Collect indices to delete
+	TypeSet<int> indicestodelete;
+
+	if ( search_forward )
+	{
+	int currentidx = startknotidx;
+	const Coord3 curpos = set_->getPos(currentidx);
+	const double dx_norm = (curpos.x_ - eraseendpos_.x_) / xy_step;
+	const double dy_norm = (curpos.y_ - eraseendpos_.y_) / xy_step;
+	const double dz_norm = (curpos.z_ - eraseendpos_.z_) / z_step;
+	double prev_dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+	indicestodelete += currentidx;
+	currentidx++;
+
+	while ( currentidx < nrpts )
+	{
+		const Coord3 knotpos = set_->getPos( currentidx );
+		if ( knotpos.isDefined() )
+		{
+		const double dx_norm = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		const double current_dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+		indicestodelete += currentidx;
+
+		if ( current_dist > prev_dist )
+			break;
+
+		prev_dist = current_dist;
+		}
+		currentidx++;
+	}
+	}
+	else
+	{
+	int currentidx = startknotidx;
+	const Coord3 curpos = set_->getPos(currentidx);
+	const double dx_norm = (curpos.x_ - eraseendpos_.x_) / xy_step;
+	const double dy_norm = (curpos.y_ - eraseendpos_.y_) / xy_step;
+	const double dz_norm = (curpos.z_ - eraseendpos_.z_) / z_step;
+	double prev_dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+	indicestodelete += currentidx;
+	currentidx--;
+
+	while ( currentidx >= 0 )
+	{
+		const Coord3 knotpos = set_->getPos( currentidx );
+		if ( knotpos.isDefined() )
+		{
+		const double dx_norm = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		const double current_dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+		indicestodelete += currentidx;
+
+		if ( current_dist > prev_dist )
+			break;
+
+		prev_dist = current_dist;
+		}
+		currentidx--;
+	}
+	}
+
+	// Sort indices in descending order
+	for ( int i=0; i<indicestodelete.size()-1; i++ )
+	{
+	for ( int j=i+1; j<indicestodelete.size(); j++ )
+	{
+		if ( indicestodelete[i] < indicestodelete[j] )
+		{
+		const int temp = indicestodelete[i];
+		indicestodelete[i] = indicestodelete[j];
+		indicestodelete[j] = temp;
+		}
+	}
+	}
+
+	// Delete in descending order
+	for ( int i=0; i<indicestodelete.size(); i++ )
+	{
+	const int idx = indicestodelete[i];
+	if ( set_->validIdx(idx) )
+		set_->removeSingleWithUndo( idx );
+	}
+
+	if ( !indicestodelete.isEmpty() )
+	{
+	Pick::Mgr().undo().setUserInteractionEnd(
+		Pick::Mgr().undo().currentEventID() );
+
+	// Trigger proper redraw
+	redrawAll();
+
+	// Also notify scene so section visibility is updated
+	if ( scene_ )
+		scene_->objectMoved( nullptr );
+	}
+}
+
+
+void PickSetDisplay::erasePointsNearPosition( const Coord3& pos )
+{
+	if ( !set_ || !pos.isDefined() )
+	return;
+
+	const int nrpts = set_->size();
+	if ( nrpts == 0 )
+	return;
+
+	// Get sampling intervals from survey info for normalized distance calculation
+	const double inl_dist = SI().inlDistance();
+	const double crl_dist = SI().crlDistance();
+	const double z_step = SI().zStep();
+	const double xy_step = (inl_dist + crl_dist) / 2.0;
+
+	// Find nearest point using normalized distances
+	int nearestidx = -1;
+	double mindist = 1e30;
+
+	for ( int idx=0; idx<nrpts; idx++ )
+	{
+	const Coord3 ptpos = set_->getPos( idx );
+	if ( !ptpos.isDefined() )
+		continue;
+
+	// Normalize distances by sampling intervals (sample space)
+	const double dx_norm = (ptpos.x_ - pos.x_) / xy_step;
+	const double dy_norm = (ptpos.y_ - pos.y_) / xy_step;
+	const double dz_norm = (ptpos.z_ - pos.z_) / z_step;
+
+	// Compute distance in "sample space"
+	const double dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+
+	if ( dist < mindist )
+	{
+		mindist = dist;
+		nearestidx = idx;
+	}
+	}
+
+	if ( nearestidx >= 0 && set_->validIdx(nearestidx) )
+	{
+	set_->removeSingleWithUndo( nearestidx );
+	Pick::Mgr().undo().setUserInteractionEnd(
+		Pick::Mgr().undo().currentEventID() );
+
+	// Trigger proper redraw
+	redrawAll();
+
+	// Also notify scene so section visibility is updated
+	if ( scene_ )
+		scene_->objectMoved( nullptr );
+	}
 }
 
 } // namespace visSurvey

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -929,11 +929,19 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	return;
 
 	// Step 1: Find the knot nearest to the START position
-	// CRITICAL FIX: Use 2D (X,Y) distance to find nearest knot,
-	// because the Z from mouse click might be on a different plane!
+	// CRITICAL: Normalize by sampling intervals (bin size and time sample rate)
+	// to compute distance in terms of SAMPLE distance, not raw coordinate distance
 
 	int startknotidx = -1;
 	double mindist_start = 1e30;
+
+	// Get sampling intervals from survey info
+	const double inl_dist = SI().inlDistance();  // Inline spacing in meters
+	const double crl_dist = SI().crlDistance();  // Crossline spacing in meters
+	const double z_step = SI().zStep();          // Z sample rate (e.g., 0.004 for 4ms)
+
+	// Use the average horizontal bin size for X,Y normalization
+	const double xy_step = (inl_dist + crl_dist) / 2.0;
 
 	for ( int idx=0; idx<nrknots; idx++ )
 	{
@@ -941,11 +949,13 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( !knotpos.isDefined() )
 		continue;
 
-	// Use 2D (X,Y) distance only - ignore Z from mouse click
-	// because mouse Z depends on which plane was clicked
-	const double dx = knotpos.x_ - erasestartpos_.x_;
-	const double dy = knotpos.y_ - erasestartpos_.y_;
-	const double dist = sqrt(dx*dx + dy*dy);
+	// Normalize distances by sampling intervals
+	const double dx_norm = (knotpos.x_ - erasestartpos_.x_) / xy_step;
+	const double dy_norm = (knotpos.y_ - erasestartpos_.y_) / xy_step;
+	const double dz_norm = (knotpos.z_ - erasestartpos_.z_) / z_step;
+
+	// Now compute distance in "sample space"
+	const double dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
 
 	if ( dist < mindist_start )
 	{
@@ -987,13 +997,14 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	// We don't use endknotidx from the global search - we'll find it sequentially!
 
 	// Step 3: Determine direction by checking which neighbor of startknotidx 
-	// is closer to the END position
+	// is closer to the END position (using normalized distances)
 
 	// Get the two neighbors of startknotidx
 	const int neighbor_forward = (startknotidx + 1 < nrknots) ? startknotidx + 1 : -1;
 	const int neighbor_backward = (startknotidx - 1 >= 0) ? startknotidx - 1 : -1;
 
-	// Calculate distances from neighbors to end position
+	// Calculate normalized distances from neighbors to end position
+	// (using xy_step and z_step already defined above)
 	double dist_forward = 1e30;
 	double dist_backward = 1e30;
 
@@ -1001,14 +1012,24 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	{
 	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, neighbor_forward) );
 	if ( knotpos.isDefined() )
-		dist_forward = eraseendpos_.distTo( knotpos );
+	{
+		const double dx = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		dist_forward = sqrt(dx*dx + dy*dy + dz*dz);
+	}
 	}
 
 	if ( neighbor_backward >= 0 )
 	{
 	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, neighbor_backward) );
 	if ( knotpos.isDefined() )
-		dist_backward = eraseendpos_.distTo( knotpos );
+	{
+		const double dx = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		dist_backward = sqrt(dx*dx + dy*dy + dz*dz);
+	}
 	}
 
 	// Determine search direction
@@ -1031,8 +1052,7 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	}
 
 	// Step 4: Follow the direction SEQUENTIALLY and find where to stop
-	// Stop when the distance to end position starts INCREASING
-	// (meaning we've passed the endpoint region)
+	// Stop when the normalized distance to end position starts INCREASING
 
 	TypeSet<int> indicestodelete;
 
@@ -1045,18 +1065,26 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	// Start with the first knot
 	const Coord3 firstpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
 	if ( firstpos.isDefined() )
-		prev_dist = eraseendpos_.distTo( firstpos );
+	{
+		const double dx = (firstpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (firstpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (firstpos.z_ - eraseendpos_.z_) / z_step;
+		prev_dist = sqrt(dx*dx + dy*dy + dz*dz);
+	}
 
 	indicestodelete += currentidx;
 	currentidx++;
 
-	// Continue while distance is decreasing (getting closer to endpoint)
+	// Continue while distance is decreasing
 	while ( currentidx < nrknots )
 	{
 		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
 		if ( knotpos.isDefined() )
 		{
-		const double current_dist = eraseendpos_.distTo( knotpos );
+		const double dx = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		const double current_dist = sqrt(dx*dx + dy*dy + dz*dz);
 
 		// Add this knot
 		indicestodelete += currentidx;
@@ -1064,7 +1092,6 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 		// If distance started increasing, we've passed the endpoint
 		if ( current_dist > prev_dist )
 		{
-			// We've included one knot past the closest point - that's fine
 			break;
 		}
 
@@ -1082,18 +1109,26 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	// Start with the first knot
 	const Coord3 firstpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
 	if ( firstpos.isDefined() )
-		prev_dist = eraseendpos_.distTo( firstpos );
+	{
+		const double dx = (firstpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (firstpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (firstpos.z_ - eraseendpos_.z_) / z_step;
+		prev_dist = sqrt(dx*dx + dy*dy + dz*dz);
+	}
 
 	indicestodelete += currentidx;
 	currentidx--;
 
-	// Continue while distance is decreasing (getting closer to endpoint)
+	// Continue while distance is decreasing
 	while ( currentidx >= 0 )
 	{
 		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
 		if ( knotpos.isDefined() )
 		{
-		const double current_dist = eraseendpos_.distTo( knotpos );
+		const double dx = (knotpos.x_ - eraseendpos_.x_) / xy_step;
+		const double dy = (knotpos.y_ - eraseendpos_.y_) / xy_step;
+		const double dz = (knotpos.z_ - eraseendpos_.z_) / z_step;
+		const double current_dist = sqrt(dx*dx + dy*dy + dz*dz);
 
 		// Add this knot
 		indicestodelete += currentidx;
@@ -1101,7 +1136,6 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 		// If distance started increasing, we've passed the endpoint
 		if ( current_dist > prev_dist )
 		{
-			// We've included one knot past the closest point - that's fine
 			break;
 		}
 

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -670,9 +670,7 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 				? scene_->getZScale() *scene_->getFixedZStretch()
 				: SI().zScale();
 
-	// Enable sower for click-and-drag if not closed
-	if ( !polygonclosed_ )
-	{
+	// Enable sower for click-and-drag (works for both open and closed polygons)
 	// Check if Ctrl is pressed for erase mode
 	const bool iserasemode = OD::ctrlKeyboardButton(eventinfo.buttonstate_);
 
@@ -780,7 +778,6 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 		if ( viseditor_->sower().accept(eventinfo) )
 		return;
 	}
-	}
 
 	if ( eventinfo.type != visBase::MouseClick ||
 	 !OD::leftMouseButton(eventinfo.buttonstate_) )
@@ -807,6 +804,11 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 
 	// Get interaction info for knot manipulation
 	EM::PosID nearestpid0, nearestpid1, insertpid;
+
+	// Safety check before calling getInteractionInfo
+	if ( !polygonsurfeditor_ || !empolygonsurf_ )
+	return;
+
 	polygonsurfeditor_->getInteractionInfo( nearestpid0, nearestpid1,
 						insertpid, pos, zscale );
 	const int nearestpolygon =
@@ -819,6 +821,9 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 	}
 
 	// Handle Ctrl+Click to remove knot/polygon
+	if ( !viseditor_ )
+	return;
+
 	const EM::PosID pid = viseditor_->mouseClickDragger(eventinfo.pickedobjids);
 	if ( !pid.isUdf() )
 	{
@@ -854,11 +859,12 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 	 OD::shiftKeyboardButton(eventinfo.buttonstate_) )
 	return;
 
-	// Don't add points if polygon is closed
-	if ( polygonclosed_ )
-	return;
+	// Allow adding points to both open and closed polygons
+	// The geometry supports this - polygonclosed_ is just a visual flag
+	// Just ensure the event is handled to prevent deselection
 
 	// Handle sower activation on press for drag mode
+	// Works for both open and closed polygons
 	if ( eventinfo.pressed )
 	{
 	// Try to activate sower for click-and-drag
@@ -868,6 +874,8 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 
 	return; // Don't add point on press, wait for release
 	}
+
+	// On release, continue to point insertion
 
 	// Only add points on mouse release
 	// Determine edit normal from plane
@@ -897,11 +905,112 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 	}
 	else
 	{
-	// Add knot to existing polygon
-	const int nrknots = empolygonsurf_->geometry().nrKnots(activepolygon);
-	const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
-	if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+	// Insert knot at the appropriate position
+	// Safety check: ensure we have valid polygon geometry
+	if ( !empolygonsurf_ )
+	{
+		eventcatcher_->setHandled();
 		return;
+	}
+
+	const int nrknots = empolygonsurf_->geometry().nrKnots(activepolygon);
+	if ( nrknots < 0 )
+	{
+		eventcatcher_->setHandled();
+		return;
+	}
+
+	// Get the geometry element for additional validation
+	mDynamicCastGet( Geometry::PolygonSurface*, polygonsurface,
+			 empolygonsurf_->geometryElement() )
+	if ( !polygonsurface )
+	{
+		eventcatcher_->setHandled();
+		return;
+	}
+
+	// Smart mode detection: Insert between neighbors OR add at end
+	// Decision based on: Are we clicking NEAR an existing line segment?
+
+	bool shouldInsertBetweenNeighbors = false;
+
+	// Check if we have valid neighbors and insertion point
+	if ( nrknots >= 2 && !insertpid.isUdf() && !nearestpid0.isUdf() && !nearestpid1.isUdf() )
+	{
+		// Get the two nearest knot positions
+		const RowCol rc0 = nearestpid0.getRowCol();
+		const RowCol rc1 = nearestpid1.getRowCol();
+		const Coord3 knotpos0 = polygonsurface->getKnot( rc0 );
+		const Coord3 knotpos1 = polygonsurface->getKnot( rc1 );
+
+		if ( knotpos0.isDefined() && knotpos1.isDefined() )
+		{
+		// Calculate distance from click position to the line segment between neighbors
+		const Coord3 segvec = knotpos1 - knotpos0;
+		const double seglen = segvec.abs();
+
+		if ( seglen > 0.001 )
+		{
+			// Project click position onto the line segment
+			const Coord3 clickvec = pos - knotpos0;
+			const double t = clickvec.dot(segvec) / (seglen * seglen);
+			const double t_clamped = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+			const Coord3 projection = knotpos0 + segvec * t_clamped;
+
+			// Calculate distance to line segment
+			const double dist_to_segment = pos.distTo( projection );
+
+			// Use normalized distance threshold (in sample space)
+			const double inl_dist = SI().inlDistance();
+			const double crl_dist = SI().crlDistance();
+			const double xy_step = (inl_dist + crl_dist) / 2.0;
+			const double threshold_distance = xy_step * 2.0; // 2 bins away
+
+			// If click is close to the line segment, insert between neighbors
+			if ( dist_to_segment < threshold_distance )
+			{
+			shouldInsertBetweenNeighbors = true;
+			}
+		}
+		}
+	}
+
+	// Execute the appropriate insertion strategy
+	if ( shouldInsertBetweenNeighbors )
+	{
+		// INSERT MODE: Click is near existing line - insert between neighbors
+		const RowCol insertrc = insertpid.getRowCol();
+		const int insertcol = insertrc.col();
+
+		if ( insertcol >= 0 && insertcol <= nrknots )
+		{
+		if ( !empolygonsurf_->geometry().insertKnot(insertpid.subID(), pos, true) )
+		{
+			eventcatcher_->setHandled();
+			return;
+		}
+		}
+		else
+		{
+		// Fallback to end if insertion position invalid
+		const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
+		if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+		{
+			eventcatcher_->setHandled();
+			return;
+		}
+		}
+	}
+	else
+	{
+		// CONSTRUCTION MODE: Click is away from polygon - add at end
+		const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
+		if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+		{
+		eventcatcher_->setHandled();
+		return;
+		}
+	}
 	}
 
 	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -681,7 +681,12 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 		// Handle Ctrl+Drag deletion - record start/end positions
 		if ( eventinfo.type == visBase::MouseClick && eventinfo.pressed )
 		{
-		// Start of Ctrl+Drag - record start position
+		// Start of Ctrl+Drag - ALWAYS reset state first
+		iserasing_ = false;
+		erasestartpos_ = Coord3::udf();
+		eraseendpos_ = Coord3::udf();
+
+		// Now record start position
 		Coord3 pos = disp2world( eventinfo.displaypickedpos );
 		if ( pos.isDefined() )
 		{
@@ -689,11 +694,6 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 			erasestartpos_ = pos;
 			eraseendpos_ = pos;
 			eventcatcher_->setHandled();
-		}
-		else
-		{
-			// Invalid position - reset state
-			iserasing_ = false;
 		}
 		return;
 		}
@@ -744,6 +744,13 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 			erasestartpos_ = Coord3::udf();
 			eraseendpos_ = Coord3::udf();
 			eventcatcher_->setHandled();
+		}
+		else
+		{
+			// Release without being in erase mode - ensure clean state
+			iserasing_ = false;
+			erasestartpos_ = Coord3::udf();
+			eraseendpos_ = Coord3::udf();
 		}
 		return;
 		}
@@ -921,7 +928,10 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( !polygonsurface )
 	return;
 
-	// Step 1: Find the knot nearest to the start position (in 3D space)
+	// Step 1: Find the knot nearest to the START position
+	// CRITICAL FIX: Use 2D (X,Y) distance to find nearest knot,
+	// because the Z from mouse click might be on a different plane!
+
 	int startknotidx = -1;
 	double mindist_start = 1e30;
 
@@ -931,7 +941,12 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( !knotpos.isDefined() )
 		continue;
 
-	const double dist = erasestartpos_.distTo( knotpos );
+	// Use 2D (X,Y) distance only - ignore Z from mouse click
+	// because mouse Z depends on which plane was clicked
+	const double dx = knotpos.x_ - erasestartpos_.x_;
+	const double dy = knotpos.y_ - erasestartpos_.y_;
+	const double dist = sqrt(dx*dx + dy*dy);
+
 	if ( dist < mindist_start )
 	{
 		mindist_start = dist;
@@ -963,85 +978,138 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( endknotidx == -1 || startknotidx == endknotidx )
 	return;
 
-	// Step 3: Determine deletion path by checking proximity to drag trajectory
-	// We want to delete knots that are close to the line segment from start to end
+	// SIMPLE APPROACH: Follow the polygon from nearest start point 
+	// and delete until we pass the end position
+
+	// Step 1 & 2: Find nearest knot to START position (already done above)
+	// startknotidx is the nearest knot to erasestartpos_
+
+	// We don't use endknotidx from the global search - we'll find it sequentially!
+
+	// Step 3: Determine direction by checking which neighbor of startknotidx 
+	// is closer to the END position
+
+	// Get the two neighbors of startknotidx
+	const int neighbor_forward = (startknotidx + 1 < nrknots) ? startknotidx + 1 : -1;
+	const int neighbor_backward = (startknotidx - 1 >= 0) ? startknotidx - 1 : -1;
+
+	// Calculate distances from neighbors to end position
+	double dist_forward = 1e30;
+	double dist_backward = 1e30;
+
+	if ( neighbor_forward >= 0 )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, neighbor_forward) );
+	if ( knotpos.isDefined() )
+		dist_forward = eraseendpos_.distTo( knotpos );
+	}
+
+	if ( neighbor_backward >= 0 )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, neighbor_backward) );
+	if ( knotpos.isDefined() )
+		dist_backward = eraseendpos_.distTo( knotpos );
+	}
+
+	// Determine search direction
+	bool search_forward = true;
+
+	if ( neighbor_forward < 0 && neighbor_backward >= 0 )
+	{
+	// Only backward neighbor exists
+	search_forward = false;
+	}
+	else if ( neighbor_backward < 0 && neighbor_forward >= 0 )
+	{
+	// Only forward neighbor exists
+	search_forward = true;
+	}
+	else
+	{
+	// Both neighbors exist, choose the one closer to end position
+	search_forward = (dist_forward <= dist_backward);
+	}
+
+	// Step 4: Follow the direction SEQUENTIALLY and find where to stop
+	// Stop when the distance to end position starts INCREASING
+	// (meaning we've passed the endpoint region)
 
 	TypeSet<int> indicestodelete;
 
-	// Build both possible paths and check which one is closer to the drag trajectory
-	TypeSet<int> path1, path2;
-
-	// Path 1: From start to end going forward (increasing indices, wrapping if needed)
-	int idx = startknotidx;
-	while ( true )
+	if ( search_forward )
 	{
-	path1 += idx;
-	if ( idx == endknotidx )
-		break;
-	idx = (idx + 1) % nrknots;
-	if ( path1.size() > nrknots )
-		break; // Safety check
-	}
+	// Search forward from startknotidx
+	int currentidx = startknotidx;
+	double prev_dist = 1e30;
 
-	// Path 2: From start to end going backward (decreasing indices, wrapping if needed)
-	idx = startknotidx;
-	while ( true )
-	{
-	path2 += idx;
-	if ( idx == endknotidx )
-		break;
-	idx = (idx - 1 + nrknots) % nrknots;
-	if ( path2.size() > nrknots )
-		break; // Safety check
-	}
+	// Start with the first knot
+	const Coord3 firstpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
+	if ( firstpos.isDefined() )
+		prev_dist = eraseendpos_.distTo( firstpos );
 
-	// Calculate which path is closer to the drag trajectory
-	double avgdist_path1 = 0.0;
-	double avgdist_path2 = 0.0;
-	int count1 = 0, count2 = 0;
+	indicestodelete += currentidx;
+	currentidx++;
 
-	// For each knot in path1, calculate distance to drag line segment
-	for ( int i=0; i<path1.size(); i++ )
+	// Continue while distance is decreasing (getting closer to endpoint)
+	while ( currentidx < nrknots )
 	{
-	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, path1[i]) );
-	if ( knotpos.isDefined() )
-	{
-		// Distance from point to line segment (simplified - using distance to midpoint)
-		const Coord3 dragmidpoint = (erasestartpos_ + eraseendpos_) * 0.5;
-		avgdist_path1 += knotpos.distTo( dragmidpoint );
-		count1++;
+		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
+		if ( knotpos.isDefined() )
+		{
+		const double current_dist = eraseendpos_.distTo( knotpos );
+
+		// Add this knot
+		indicestodelete += currentidx;
+
+		// If distance started increasing, we've passed the endpoint
+		if ( current_dist > prev_dist )
+		{
+			// We've included one knot past the closest point - that's fine
+			break;
+		}
+
+		prev_dist = current_dist;
+		}
+		currentidx++;
 	}
 	}
-	if ( count1 > 0 )
-	avgdist_path1 /= count1;
+	else
+	{
+	// Search backward from startknotidx
+	int currentidx = startknotidx;
+	double prev_dist = 1e30;
 
-	// For each knot in path2, calculate distance to drag line segment
-	for ( int i=0; i<path2.size(); i++ )
+	// Start with the first knot
+	const Coord3 firstpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
+	if ( firstpos.isDefined() )
+		prev_dist = eraseendpos_.distTo( firstpos );
+
+	indicestodelete += currentidx;
+	currentidx--;
+
+	// Continue while distance is decreasing (getting closer to endpoint)
+	while ( currentidx >= 0 )
 	{
-	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, path2[i]) );
-	if ( knotpos.isDefined() )
-	{
-		const Coord3 dragmidpoint = (erasestartpos_ + eraseendpos_) * 0.5;
-		avgdist_path2 += knotpos.distTo( dragmidpoint );
-		count2++;
+		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, currentidx) );
+		if ( knotpos.isDefined() )
+		{
+		const double current_dist = eraseendpos_.distTo( knotpos );
+
+		// Add this knot
+		indicestodelete += currentidx;
+
+		// If distance started increasing, we've passed the endpoint
+		if ( current_dist > prev_dist )
+		{
+			// We've included one knot past the closest point - that's fine
+			break;
+		}
+
+		prev_dist = current_dist;
+		}
+		currentidx--;
 	}
 	}
-	if ( count2 > 0 )
-	avgdist_path2 /= count2;
-
-	// Choose the path that's closer to the drag trajectory
-	const TypeSet<int>& pathToDelete = (avgdist_path1 <= avgdist_path2) ? path1 : path2;
-
-	// Safety check: don't delete all knots
-	if ( pathToDelete.size() >= nrknots )
-	{
-	// Would delete everything - abort
-	return;
-	}
-
-	// Copy indices to delete
-	for ( int i=0; i<pathToDelete.size(); i++ )
-	indicestodelete += pathToDelete[i];
 
 	// Delete knots in reverse order of their indices (to maintain valid indices)
 	// Sort indices in descending order first
@@ -1060,18 +1128,33 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	}
 
 	// Now delete in descending order
+	// Each removeKnot with true creates its own undo event
+	// They will be grouped together if no setUserInteractionEnd is called between them
+
+	// Safety check: ensure we have valid geometry
+	if ( !empolygonsurf_ || indicestodelete.isEmpty() )
+		return;
+
+	int deletedcount = 0;
 	for ( int i=0; i<indicestodelete.size(); i++ )
 	{
 	const int knotidx = indicestodelete[i];
-	if ( knotidx >= 0 && knotidx < empolygonsurf_->geometry().nrKnots(activepolygon) )
+	const int currentnrknots = empolygonsurf_->geometry().nrKnots(activepolygon);
+
+	// Bounds check with current knot count
+	if ( knotidx >= 0 && knotidx < currentnrknots )
 	{
 		const EM::SubID subid = RowCol(activepolygon, knotidx).toInt64();
-		empolygonsurf_->geometry().removeKnot( subid, true );
+		// Use true to properly register undo events
+		const bool success = empolygonsurf_->geometry().removeKnot( subid, true );
+		if ( success )
+			deletedcount++;
 	}
 	}
 
-	// Update undo and display
-	if ( indicestodelete.size() > 0 )
+	// Close the undo event ONLY ONCE after all deletions
+	// This groups all the individual undo events into one user interaction
+	if ( deletedcount > 0 )
 	{
 	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
 		EM::EMM().undo(empolygonsurf_->id()).currentEventID() );

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -374,12 +374,19 @@ void PolygonBodyDisplay::touchAll( bool yn, bool updatemarker )
 		if ( !colrg.isUdf() )
 		{
 		// Add all knots as straight line segments
+		// CRITICAL: Apply display transformation to convert world ? display coordinates
 		for ( int col=colrg.start_; col<=colrg.stop_; col+=colrg.step_ )
 		{
 			const Coord3 pos = 
 			polygonsurface->getKnot( RowCol(activepolygon,col) );
 			if ( pos.isDefined() )
-			openpolygonline_->addPoint( pos );
+			{
+			Coord3 displaypos = pos;
+			// Apply display transformation if available
+			if ( displaytransform_ )
+				displaytransform_->transform( displaypos );
+			openpolygonline_->addPoint( displaypos );
+			}
 		}
 
 		// If closed, add first point again to close the loop
@@ -388,7 +395,13 @@ void PolygonBodyDisplay::touchAll( bool yn, bool updatemarker )
 			const Coord3 firstpos = 
 			polygonsurface->getKnot( RowCol(activepolygon, colrg.start_) );
 			if ( firstpos.isDefined() )
-			openpolygonline_->addPoint( firstpos );
+			{
+			Coord3 displaypos = firstpos;
+			// Apply display transformation if available
+			if ( displaytransform_ )
+				displaytransform_->transform( displaypos );
+			openpolygonline_->addPoint( displaypos );
+			}
 		}
 		}
 	}

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -30,24 +30,27 @@ namespace visSurvey
 PolygonBodyDisplay::PolygonBodyDisplay()
     : visBase::VisualObjectImpl(true)
 {
-    ref();
-    nearestpolygonmarker_ = visBase::PolyLine3D::create();
-    drawstyle_ = visBase::DrawStyle::create();
-    intsurf_ = visBase::TriangleStripSet::create();
-    if ( !nearestpolygonmarker_->getMaterial() )
-    {
+	ref();
+	nearestpolygonmarker_ = visBase::PolyLine3D::create();
+	drawstyle_ = visBase::DrawStyle::create();
+	intsurf_ = visBase::TriangleStripSet::create();
+	if ( !nearestpolygonmarker_->getMaterial() )
+	{
 	RefMan<visBase::Material> newmat = visBase::Material::create();
+	newmat->setColor( OD::Color(255, 255, 0) );  // Yellow
 	nearestpolygonmarker_->setMaterial( newmat.ptr() );
-    }
+	}
 
-    addChild( nearestpolygonmarker_->osgNode() );
-    getMaterial()->setAmbience( 0.2 );
+	addChild( nearestpolygonmarker_->osgNode() );
+	getMaterial()->setAmbience( 0.2 );
 
-    nearestpolygonmarker_->setPrimitiveType(Geometry::PrimitiveSet::LineStrips);
+	nearestpolygonmarker_->setPrimitiveType(Geometry::PrimitiveSet::LineStrips);
 
-    drawstyle_->setLineStyle( OD::LineStyle(OD::LineStyle::Solid,2) );
+	// Set line style with width 3 and yellow color
+	drawstyle_->setLineStyle( OD::LineStyle(OD::LineStyle::Solid, 3, OD::Color(255, 255, 0)) );
+	nearestpolygonmarker_->setLineStyle( OD::LineStyle(OD::LineStyle::Solid, 3, OD::Color(255, 255, 0)) );
 
-    intsurf_->turnOn( false );
+	intsurf_->turnOn( false );
     intsurf_->setNormalBindType( visBase::VertexShape::BIND_PER_VERTEX );
     intsurf_->setColorBindType( visBase::VertexShape::BIND_OVERALL );
     intsurf_->setRenderMode( visBase::RenderBothSides );
@@ -235,8 +238,8 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 	setLineRadius( intersectiondisplay_.ptr() );
     }
 
-    if ( !polygondisplay_ )
-    {
+	if ( !polygondisplay_ )
+	{
 	polygondisplay_ = visBase::GeomIndexedShape::create();
 	polygondisplay_->setDisplayTransformation( displaytransform_.ptr() );
 	polygondisplay_->setMaterial( getMaterial() );
@@ -246,7 +249,9 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 					Geometry::PrimitiveSet::LineStrips );
 	addChild( polygondisplay_->osgNode() );
 	setLineRadius( polygondisplay_.ptr() );
-    }
+	// Always keep this off - we use openpolygonline_ instead
+	polygondisplay_->turnOn( false );
+	}
 
     const float zscale = scene_
 			? scene_->getZScale() *scene_->getFixedZStretch()
@@ -258,35 +263,77 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 	explicitbody_->display( false, true );
     }
 
-    if ( !explicitpolygons_ )
-    {
+	if ( !explicitpolygons_ )
+	{
 	explicitpolygons_ = new Geometry::ExplPolygonSurface( 0, zscale );
-	explicitpolygons_->display( true, false );
-    }
+	explicitpolygons_->display( false, false );  // Don't display - we use openpolygonline_
+	}
 
-    if ( !explicitintersections_ )
+	if ( !explicitintersections_ )
 	explicitintersections_ = new Geometry::ExplPlaneIntersection();
 
-    mDynamicCastGet( Geometry::PolygonSurface*, polygonsurface,
-		     empolygonsurf_->geometryElement())
+	mDynamicCastGet( Geometry::PolygonSurface*, polygonsurface,
+			 empolygonsurf_->geometryElement())
 
-    explicitbody_->setPolygonSurface( polygonsurface );
-    bodydisplay_->setSurface( explicitbody_ );
+	explicitbody_->setPolygonSurface( polygonsurface );
+	bodydisplay_->setSurface( explicitbody_ );
 
-    explicitintersections_->setShape( *explicitbody_ );
-    intersectiondisplay_->setSurface( explicitintersections_ );
+	explicitintersections_->setShape( *explicitbody_ );
+	intersectiondisplay_->setSurface( explicitintersections_ );
 
-    explicitpolygons_->setPolygonSurface( polygonsurface );
-    polygondisplay_->setSurface( explicitpolygons_ );
+	// Don't set surface for polygon display - we're not using it
+	// explicitpolygons_->setPolygonSurface( polygonsurface );
+	// polygondisplay_->setSurface( explicitpolygons_ );
 
-    if ( !viseditor_ )
-    {
+	// Force polygon display OFF - never use it
+	polygondisplay_->turnOn( false );
+
+	// Create our custom polygon line early
+	if ( !openpolygonline_ )
+	{
+	openpolygonline_ = visBase::PolyLine::create();
+	openpolygonline_->setDisplayTransformation( displaytransform_.ptr() );
+
+	// Create and set material with yellow color
+	RefMan<visBase::Material> linemat = visBase::Material::create();
+	linemat->setColor( OD::Color(255, 255, 0) );  // Yellow
+	openpolygonline_->setMaterial( linemat.ptr() );
+
+	// Set line style with width 3 and YELLOW color
+	OD::LineStyle lnstyle( OD::LineStyle::Solid, 3, OD::Color(255, 255, 0) );
+	openpolygonline_->setLineStyle( lnstyle );
+
+	// Add to scene graph
+	addChild( openpolygonline_->osgNode() );
+
+	// Note: setLineStyle with width>0 automatically turns it on (line 100 in vispolyline.cc)
+	}
+
+	if ( !viseditor_ )
+	{
 	viseditor_ = MPEEditor::create();
 	viseditor_->setSceneEventCatcher( eventcatcher_.ptr() );
 	viseditor_->setDisplayTransformation( displaytransform_.ptr() );
-	viseditor_->sower().alternateSowingOrder();
+
+	// DON'T use alternateSowingOrder - it causes zig-zag
+	// viseditor_->sower().alternateSowingOrder();
+
+	// Connect to sowing finished callback
+	viseditor_->sower().sowingend.notify( mCB(this,PolygonBodyDisplay,sowingFinishedCB) );
+
 	addChild( viseditor_->osgNode() );
-    }
+
+	// Ensure markers render on top of lines
+	viseditor_->turnOn( true );
+
+	// Set marker style: size 5, yellow color, Cube shape
+	MarkerStyle3D markerstyle;
+	markerstyle.type_ = MarkerStyle3D::Cube;
+	markerstyle.size_ = 5;
+	markerstyle.color_ = OD::Color(255, 255, 0);  // Yellow
+	viseditor_->setMarkerStyle( markerstyle );
+	viseditor_->setMarkerSize( 5.0f );
+	}
 
     RefMan<MPE::ObjectEditor> polygonsurfeditor = getMPEEditor( true );
     if ( polygonsurfeditor )
@@ -306,20 +353,88 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 
 void PolygonBodyDisplay::touchAll( bool yn, bool updatemarker )
 {
-    if ( bodydisplay_ )
+	if ( bodydisplay_ )
 	bodydisplay_->touch( yn );
 
-    if ( polygondisplay_ )
-	polygondisplay_->touch( yn );
+	// Always use custom rendering for polygon tracking (no Bezier)
+	const int nrpolygons = empolygonsurf_ ? 
+		empolygonsurf_->geometry().nrPolygons() : 0;
 
-    if ( intersectiondisplay_ )
-    {
+	if ( nrpolygons > 0 && openpolygonline_ )
+	{
+	// Update polygon line with current knots (straight line segments)
+	openpolygonline_->removeAllPoints();
+	mDynamicCastGet( const Geometry::PolygonSurface*, polygonsurface,
+			 empolygonsurf_->geometryElement() )
+	if ( polygonsurface )
+	{
+		const int activepolygon = 0;
+		const StepInterval<int> colrg = 
+		polygonsurface->colRange( activepolygon );
+		if ( !colrg.isUdf() )
+		{
+		// Add all knots as straight line segments
+		for ( int col=colrg.start_; col<=colrg.stop_; col+=colrg.step_ )
+		{
+			const Coord3 pos = 
+			polygonsurface->getKnot( RowCol(activepolygon,col) );
+			if ( pos.isDefined() )
+			openpolygonline_->addPoint( pos );
+		}
+
+		// If closed, add first point again to close the loop
+		if ( polygonclosed_ && colrg.width() > 0 )
+		{
+			const Coord3 firstpos = 
+			polygonsurface->getKnot( RowCol(activepolygon, colrg.start_) );
+			if ( firstpos.isDefined() )
+			openpolygonline_->addPoint( firstpos );
+		}
+		}
+	}
+
+	// Notify that coordinates have changed
+	openpolygonline_->dirtyCoordinates();
+
+	// Only turn on line if we have at least 2 points
+	const int nrpoints = openpolygonline_->size();
+	if ( nrpoints >= 2 )
+		openpolygonline_->turnOn( true );
+	else
+		openpolygonline_->turnOn( false );
+	}
+	else
+	{
+	// No polygons - hide everything
+	if ( openpolygonline_ )
+		openpolygonline_->turnOn( false );
+	}
+
+	// ALWAYS hide the default Bezier-based polygon display
+	if ( polygondisplay_ )
+	{
+	polygondisplay_->turnOn( false );
+	polygondisplay_->touch( yn );
+	}
+
+	if ( intersectiondisplay_ )
+	{
 	intersectiondisplay_->touch( yn );
 	reMakeIntersectionSurface();
-    }
+	}
 
-    if ( updatemarker )
+	if ( updatemarker )
 	updateNearestPolygonMarker();
+}
+
+
+void PolygonBodyDisplay::closePolygon()
+{
+	if ( !polygonclosed_ )
+	{
+	polygonclosed_ = true;
+	touchAll( false, true );  // Force marker update to show closing segment
+	}
 }
 
 
@@ -383,30 +498,31 @@ OD::Color PolygonBodyDisplay::getColor() const
 
 void PolygonBodyDisplay::updatePolygonDisplay()
 {
-    if ( !polygondisplay_ )
+	if ( !polygondisplay_ )
 	return;
 
-    const bool dodisplay = displaypolygons_ ||
-	(isBodyDisplayed() && isManipulatorShown()) ||
-	(isBodyDisplayed() && empolygonsurf_->geometry().nrPolygons()==1);
-
-    polygondisplay_->turnOn( dodisplay );
+	// Never show the default Bezier polygon display - we use custom openpolygonline_ instead
+	polygondisplay_->turnOn( false );
 }
 
 
 void PolygonBodyDisplay::display( bool polygons, bool body )
 {
-    displaypolygons_ = polygons;
+	displaypolygons_ = polygons;
 
-    if ( nearestpolygonmarker_ )
+	if ( nearestpolygonmarker_ )
 	nearestpolygonmarker_->turnOn( polygons || body );
 
-    viseditor_->turnOn( (polygons || body) && showmanipulator_ );
+	viseditor_->turnOn( (polygons || body) && showmanipulator_ );
 
-    if ( bodydisplay_ )
+	if ( bodydisplay_ )
 	bodydisplay_->turnOn( body );
 
-    updatePolygonDisplay();
+	// Show our custom polygon line if polygons should be displayed
+	if ( openpolygonline_ )
+	openpolygonline_->turnOn( polygons );
+
+	updatePolygonDisplay();
 }
 
 
@@ -523,147 +639,375 @@ Coord3 PolygonBodyDisplay::disp2world( const Coord3& displaypos ) const
 
 void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 {
-    if ( !empolygonsurf_ || !polygonsurfeditor_ || !isOn() || !viseditor_ ||
-	 !viseditor_->isOn() || eventcatcher_->isHandled() || !isSelected() )
+	if ( !empolygonsurf_ || !polygonsurfeditor_ || !isOn() || !viseditor_ ||
+	 !viseditor_->isOn() || !isSelected() )
 	return;
 
-    mCBCapsuleUnpack(const visBase::EventInfo&,eventinfo,cb);
+	mCBCapsuleUnpack(const visBase::EventInfo&,eventinfo,cb);
 
-    polygonsurfeditor_->setSowingPivot(
-				disp2world(viseditor_->sower().pivotPos()) );
-    if ( viseditor_->sower().accept(eventinfo) )
+	if ( locked_ )
 	return;
 
-    TrcKeyZSampling mouseplanecs;
-    mouseplanecs.setEmpty();
+	// Handle double-click to close polygon BEFORE checking if handled
+	if ( eventinfo.type == visBase::MouseDoubleClick )
+	{
+	const int nrpolygons = empolygonsurf_->geometry().nrPolygons();
+	if ( nrpolygons > 0 && !polygonclosed_ )
+	{
+		// Close the polygon
+		polygonclosed_ = true;
+		touchAll( false, true );  // Force marker update to show closing segment
+		eventcatcher_->setHandled();
+	}
+	return;
+	}
 
-    for ( int idx=0; idx<eventinfo.pickedobjids.size(); idx++ )
-    {
+	// Check if already handled after double-click check
+	if ( eventcatcher_->isHandled() )
+	return;
+
+	const float zscale = scene_
+				? scene_->getZScale() *scene_->getFixedZStretch()
+				: SI().zScale();
+
+	// Enable sower for click-and-drag if not closed
+	if ( !polygonclosed_ )
+	{
+	// Check if Ctrl is pressed for erase mode
+	const bool iserasemode = OD::ctrlKeyboardButton(eventinfo.buttonstate_);
+
+	if ( iserasemode )
+	{
+		// Handle Ctrl+Drag deletion - record start/end positions
+		if ( eventinfo.type == visBase::MouseClick && eventinfo.pressed )
+		{
+		// Start of Ctrl+Drag - record start position
+		Coord3 pos = disp2world( eventinfo.displaypickedpos );
+		if ( pos.isDefined() )
+		{
+			iserasing_ = true;
+			erasestartpos_ = pos;
+			eraseendpos_ = pos;
+			eventcatcher_->setHandled();
+		}
+		return;
+		}
+		else if ( eventinfo.type == visBase::MouseMovement && eventinfo.pressed )
+		{
+		// During drag - update end position
+		if ( iserasing_ )
+		{
+			Coord3 pos = disp2world( eventinfo.displaypickedpos );
+			if ( pos.isDefined() )
+			eraseendpos_ = pos;
+			eventcatcher_->setHandled();
+		}
+		return;
+		}
+		else if ( eventinfo.type == visBase::MouseClick && !eventinfo.pressed )
+		{
+		// End of Ctrl+Drag - check if it was a drag or just a click
+		if ( iserasing_ )
+		{
+			Coord3 pos = disp2world( eventinfo.displaypickedpos );
+			if ( pos.isDefined() )
+			{
+			eraseendpos_ = pos;
+
+			// Check if there was actual movement (drag) vs just a click
+			const double dx = fabs(eraseendpos_.x_ - erasestartpos_.x_);
+			const double dy = fabs(eraseendpos_.y_ - erasestartpos_.y_);
+			const double dragdist = sqrt(dx*dx + dy*dy);
+			const double clickthreshold = 10.0; // Minimum distance to be considered a drag
+
+			if ( dragdist > clickthreshold )
+			{
+				// It was a drag - delete all points in rectangle
+				eraseKnotsBetweenDragPositions();
+			}
+			else
+			{
+				// It was just a click - delete single nearest point
+				eraseKnotsNearPosition( pos );
+			}
+
+			iserasing_ = false;
+			}
+			eventcatcher_->setHandled();
+		}
+		return;
+		}
+	}
+	else
+	{
+		// Normal sowing mode
+		polygonsurfeditor_->setSowingPivot( 
+		disp2world(viseditor_->sower().pivotPos()) );
+
+		if ( viseditor_->sower().accept(eventinfo) )
+		return;
+	}
+	}
+
+	if ( eventinfo.type != visBase::MouseClick ||
+	 !OD::leftMouseButton(eventinfo.buttonstate_) )
+	return;
+
+	Coord3 pos = disp2world( eventinfo.displaypickedpos );
+	if ( !pos.isDefined() )
+	return;
+
+	// Get plane information for edit normal
+	TrcKeyZSampling mouseplanecs;
+	mouseplanecs.setEmpty();
+	for ( int idx=0; idx<eventinfo.pickedobjids.size(); idx++ )
+	{
 	const VisID visid = eventinfo.pickedobjids[idx];
 	visBase::DataObject* dataobj = visBase::DM().getObject( visid );
 	mDynamicCastGet(PlaneDataDisplay*,plane,dataobj)
 	if ( plane )
 	{
-	    mouseplanecs = plane->getTrcKeyZSampling();
-	    break;
+		mouseplanecs = plane->getTrcKeyZSampling();
+		break;
 	}
-    }
+	}
 
-    if ( locked_ )
-	return;
-
-    Coord3 pos = disp2world( eventinfo.displaypickedpos );
-
-    EM::PosID nearestpid0, nearestpid1, insertpid;
-    const float zscale = scene_
-			    ? scene_->getZScale() *scene_->getFixedZStretch()
-			    : SI().zScale();
-
-    polygonsurfeditor_->getInteractionInfo( nearestpid0, nearestpid1,
-					    insertpid, pos, zscale );
-    const int nearestpolygon =
+	// Get interaction info for knot manipulation
+	EM::PosID nearestpid0, nearestpid1, insertpid;
+	polygonsurfeditor_->getInteractionInfo( nearestpid0, nearestpid1,
+						insertpid, pos, zscale );
+	const int nearestpolygon =
 	nearestpid0.isUdf() ? mUdf(int) : insertpid.getRowCol().row();
 
-    if ( nearestpolygon_!=nearestpolygon )
-    {
+	if ( nearestpolygon_!=nearestpolygon )
+	{
 	nearestpolygon_ = nearestpolygon;
 	updateNearestPolygonMarker();
-    }
+	}
 
-    if ( !pos.isDefined() )
-	return;
-
-    if ( eventinfo.type!=visBase::MouseClick )
-	return;
-
-    const EM::PosID pid = viseditor_->mouseClickDragger(eventinfo.pickedobjids);
-    if ( !pid.isUdf() )
-    {
-	if ( OD::ctrlKeyboardButton(eventinfo.buttonstate_) &&
-	     !OD::altKeyboardButton(eventinfo.buttonstate_) &&
-	     !OD::shiftKeyboardButton(eventinfo.buttonstate_) &&
-	     OD::leftMouseButton(eventinfo.buttonstate_) )
+	// Handle Ctrl+Click to remove knot/polygon
+	const EM::PosID pid = viseditor_->mouseClickDragger(eventinfo.pickedobjids);
+	if ( !pid.isUdf() )
 	{
-	    eventcatcher_->setHandled();
-	    if ( !eventinfo.pressed )
-	    {
+	if ( OD::ctrlKeyboardButton(eventinfo.buttonstate_) &&
+		 !OD::altKeyboardButton(eventinfo.buttonstate_) &&
+		 !OD::shiftKeyboardButton(eventinfo.buttonstate_) &&
+		 !eventinfo.pressed )
+	{
 		const int removepolygon = pid.getRowCol().row();
 		const bool res = empolygonsurf_->geometry().nrKnots(
 			removepolygon)==1  ?
-		    empolygonsurf_->geometry().removePolygon(
-			    removepolygon, true )
-		    : empolygonsurf_->geometry().removeKnot(
-			    pid.subID(), true );
+		empolygonsurf_->geometry().removePolygon(
+			removepolygon, true )
+		: empolygonsurf_->geometry().removeKnot(
+			pid.subID(), true );
 
 		polygonsurfeditor_->setLastClicked( EM::PosID::udf() );
 
-		if ( res && !viseditor_->sower().moreToSow() )
+		if ( res )
 		{
-		    EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
+		EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
 			EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
-		    touchAll( false );
+		touchAll( false );
 		}
-	    }
+		eventcatcher_->setHandled();
+	}
+	return;
 	}
 
-	return;
-    }
-
-    if ( OD::altKeyboardButton(eventinfo.buttonstate_) ||
+	// Don't add points if modifier keys are pressed
+	if ( OD::altKeyboardButton(eventinfo.buttonstate_) ||
 	 OD::ctrlKeyboardButton(eventinfo.buttonstate_) ||
-	 !OD::leftMouseButton(eventinfo.buttonstate_) )
+	 OD::shiftKeyboardButton(eventinfo.buttonstate_) )
 	return;
 
-    if ( mouseplanecs.isEmpty() )
+	// Don't add points if polygon is closed
+	if ( polygonclosed_ )
 	return;
 
-    const OD::Color& prefcol = empolygonsurf_->preferredColor();
-    if ( viseditor_->sower().activate(prefcol, eventinfo) )
-	return;
+	// Handle sower activation on press for drag mode
+	if ( eventinfo.pressed )
+	{
+	// Try to activate sower for click-and-drag
+	const OD::Color& prefcol = empolygonsurf_->preferredColor();
+	if ( viseditor_->sower().activate(prefcol, eventinfo) )
+		return;
 
-    if ( eventinfo.pressed || insertpid.isUdf() )
-	return;
+	return; // Don't add point on press, wait for release
+	}
 
-    if ( nearestpid0.isUdf() )
-    {
+	// Only add points on mouse release
+	// Determine edit normal from plane
 	Coord3 editnormal(0,0,1);
-
+	if ( !mouseplanecs.isEmpty() )
+	{
 	if ( mouseplanecs.defaultDir()==TrcKeyZSampling::Inl )
-	    editnormal = Coord3( SI().transform(BinID(1,0)) -
+		editnormal = Coord3( SI().transform(BinID(1,0)) -
 				 SI().transform(BinID(0,0)), 0 );
 	else if ( mouseplanecs.defaultDir()==TrcKeyZSampling::Crl )
-	    editnormal = Coord3( SI().transform(BinID(0,1)) -
+		editnormal = Coord3( SI().transform(BinID(0,1)) -
 				 SI().transform(BinID(0,0)), 0 );
+	}
 
-	if ( empolygonsurf_->geometry().insertPolygon(
-	       insertpid.getRowCol().row(), 0, pos, editnormal, true ) )
+	// Get or create active polygon (always use polygon 0 for simplicity)
+	const int nrpolygons = empolygonsurf_->geometry().nrPolygons();
+	const int activepolygon = 0;
+
+	// If no polygon exists, create one
+	if ( nrpolygons == 0 )
 	{
-	    polygonsurfeditor_->setLastClicked( insertpid );
-	    if ( !viseditor_->sower().moreToSow() )
-	    {
-		EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
-		    EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
+	if ( !empolygonsurf_->geometry().insertPolygon(
+		activepolygon, 0, pos, editnormal, true ) )
+		return;
 
+	polygonclosed_ = false; // Start with open polygon
+	}
+	else
+	{
+	// Add knot to existing polygon
+	const int nrknots = empolygonsurf_->geometry().nrKnots(activepolygon);
+	const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
+	if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+		return;
+	}
+
+	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
+	EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
+	touchAll( false );
+	polygonsurfeditor_->editpositionchange.trigger();
+	eventcatcher_->setHandled();
+}
+
+
+void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
+{
+	if ( !empolygonsurf_ || !erasestartpos_.isDefined() || !eraseendpos_.isDefined() )
+	return;
+
+	const int activepolygon = 0;
+	const int nrknots = empolygonsurf_->geometry().nrKnots( activepolygon );
+	if ( nrknots == 0 )
+	return;
+
+	// Get the geometry element to access knot positions
+	mDynamicCastGet( Geometry::PolygonSurface*, polygonsurface,
+			 empolygonsurf_->geometryElement() )
+	if ( !polygonsurface )
+	return;
+
+	// Get lateral (XY) bounds of the drag trajectory with margin
+	const double minx = mMIN( erasestartpos_.x_, eraseendpos_.x_ );
+	const double maxx = mMAX( erasestartpos_.x_, eraseendpos_.x_ );
+	const double miny = mMIN( erasestartpos_.y_, eraseendpos_.y_ );
+	const double maxy = mMAX( erasestartpos_.y_, eraseendpos_.y_ );
+
+	// Add margin to the rectangle to capture nearby points
+	const double margin = 100.0; // ~4 bins width for deletion tolerance
+	const double minx_margin = minx - margin;
+	const double maxx_margin = maxx + margin;
+	const double miny_margin = miny - margin;
+	const double maxy_margin = maxy + margin;
+
+	// SIMPLER APPROACH: Just identify and delete knots INSIDE the rectangle
+	// Build list of knot indices to delete (in reverse order)
+	TypeSet<int> indicestodelete;
+
+	for ( int idx=0; idx<nrknots; idx++ )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, idx) );
+	if ( !knotpos.isDefined() )
+		continue;
+
+	// Check if knot is INSIDE the drag rectangle (with margin)
+	const bool insiderectangle = (knotpos.x_ >= minx_margin && knotpos.x_ <= maxx_margin && 
+					  knotpos.y_ >= miny_margin && knotpos.y_ <= maxy_margin);
+
+	if ( insiderectangle )
+	{
+		indicestodelete += idx;
+	}
+	}
+
+	// Safety check: don't delete all knots
+	if ( indicestodelete.size() >= nrknots )
+	{
+	// Would delete everything - abort
+	return;
+	}
+
+	// Delete knots in reverse order (to maintain valid indices)
+	for ( int i=indicestodelete.size()-1; i>=0; i-- )
+	{
+	const int knotidx = indicestodelete[i];
+	const EM::SubID subid = RowCol(activepolygon, knotidx).toInt64();
+	empolygonsurf_->geometry().removeKnot( subid, true );
+	}
+
+	// Update undo and display
+	if ( indicestodelete.size() > 0 )
+	{
+	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
+		EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
+	touchAll( false );
+	}
+}
+
+
+void PolygonBodyDisplay::sowingFinishedCB( CallBacker* )
+{
+	// The sower has finished, update the display
+	// Note: We can't access sowinghistory_ directly as it's private
+	// The points should have been added already by the standard mechanism
+	// Just update the display
+	touchAll( false );
+}
+
+
+void PolygonBodyDisplay::eraseKnotsNearPosition( const Coord3& pos )
+{
+	if ( !empolygonsurf_ || !polygonsurfeditor_ )
+	return;
+
+	const float zscale = scene_ ? scene_->getZScale() * scene_->getFixedZStretch()
+				: SI().zScale();
+
+	// Get interaction info to find nearest knot
+	EM::PosID nearestpid0, nearestpid1, insertpid;
+	polygonsurfeditor_->getInteractionInfo( nearestpid0, nearestpid1,
+						insertpid, pos, zscale );
+
+	// Define a threshold distance for erasing (in display units)
+	const float erasethreshold = 50.0f * zscale; // Adjust as needed
+
+	// Check if we're close enough to a knot to erase it
+	if ( !nearestpid0.isUdf() )
+	{
+	const Coord3 knotpos = empolygonsurf_->getPos( nearestpid0 );
+	if ( knotpos.isDefined() )
+	{
+		const float dist = (float) pos.distTo( knotpos );
+		if ( dist < erasethreshold )
+		{
+		// Remove this knot
+		const int polygon = nearestpid0.getRowCol().row();
+		const int nrknots = empolygonsurf_->geometry().nrKnots( polygon );
+
+		if ( nrknots == 1 )
+		{
+			// Last knot - remove entire polygon
+			empolygonsurf_->geometry().removePolygon( polygon, true );
+		}
+		else
+		{
+			// Remove just this knot
+			empolygonsurf_->geometry().removeKnot( nearestpid0.subID(), true );
+		}
+
+		// Update display
 		touchAll( false );
-		polygonsurfeditor_->editpositionchange.trigger();
-	    }
+		}
 	}
-    }
-    else
-    {
-	if ( empolygonsurf_->geometry().insertKnot(insertpid.subID(),pos,true) )
-	{
-	    polygonsurfeditor_->setLastClicked( insertpid );
-	    if ( !viseditor_->sower().moreToSow() )
-	    {
-		EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
-		    EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
-		polygonsurfeditor_->editpositionchange.trigger();
-	    }
 	}
-    }
-
-    eventcatcher_->setHandled();
 }
 
 
@@ -696,65 +1040,175 @@ void PolygonBodyDisplay::emChangeCB( CallBacker* cb )
 
 void PolygonBodyDisplay::updateNearestPolygonMarker()
 {
-    if ( mIsUdf(nearestpolygon_) || !isManipulatorShown() )
+	if ( mIsUdf(nearestpolygon_) || !isManipulatorShown() )
 	nearestpolygonmarker_->turnOn( false );
-    else
-    {
+	else
+	{
 	mDynamicCastGet( Geometry::PolygonSurface*, plgs,
 			 empolygonsurf_->geometryElement())
 
 	const StepInterval<int> rowrg = plgs->rowRange();
-	if ( rowrg.isUdf() || !rowrg.includes(nearestpolygon_,false) )
+	if ( rowrg.isUdf() || rowrg.width() < 0 )
 	{
-	    nearestpolygonmarker_->turnOn( false );
-	    return;
+		nearestpolygonmarker_->turnOn( false );
+		return;
 	}
 
-	const StepInterval<int> colrg = plgs->colRange( nearestpolygon_ );
+	// Always use polygon 0 for our single-polygon workflow
+	const int displaypolygon = 0;
+	if ( !rowrg.includes(displaypolygon, false) )
+	{
+		nearestpolygonmarker_->turnOn( false );
+		return;
+	}
+
+	const StepInterval<int> colrg = plgs->colRange( displaypolygon );
 	if ( colrg.isUdf() || colrg.start_==colrg.stop_ )
 	{
-	    nearestpolygonmarker_->turnOn( false );
-	    return;
+		nearestpolygonmarker_->turnOn( false );
+		return;
 	}
 
 	nearestpolygonmarker_->removeAllPrimitiveSets();
 	nearestpolygonmarker_->getCoordinates()->setEmpty();
 
-	int markeridx = 0;
-	TypeSet<Coord3> knots;
+	// Use nearestpolygonmarker to draw SMOOTH interpolated lines
+	// Get the knots and interpolate between them
 	TypeSet<int> idxps;
-	const float zfactor = scene_ ? scene_->getZScale() : SI().zScale();
-	plgs->getCubicBezierCurve( nearestpolygon_, knots, zfactor  );
-	for ( int idy=0; idy<knots.size(); idy++ )
+
+	// Collect all knot positions
+	TypeSet<Coord3> rawknots;
+	for ( int col=colrg.start_; col<=colrg.stop_; col+=colrg.step_ )
 	{
-	    nearestpolygonmarker_->getCoordinates()->addPos(knots[idy]);
-	    idxps.add( markeridx++ );
+		const Coord3 pos = plgs->getKnot( RowCol(displaypolygon, col) );
+		if ( pos.isDefined() )
+		rawknots += pos;
 	}
 
-	if ( markeridx>2 )
+	// Generate smooth interpolated curve through knots
+	const int nrknots = rawknots.size();
+	if ( nrknots >= 2 )
 	{
-	    nearestpolygonmarker_->getCoordinates()->addPos(knots[0]);
-	    idxps.add( markeridx++ );
-	}
+		// Add interpolated points between each pair of knots
+		const int interpsteps = 10; // Points per segment for smooth curve
 
-	RefMan<Geometry::IndexedPrimitiveSet> primitiveset =
-			    Geometry::IndexedPrimitiveSet::create( false );
-	idxps.add( idxps[0] );
-	primitiveset->append( idxps.arr(), idxps.size() );
-	nearestpolygonmarker_->addPrimitiveSet( primitiveset.ptr() );
-	nearestpolygonmarker_->turnOn( true );
-    }
+		for ( int kidx=0; kidx<nrknots-1; kidx++ )
+		{
+		const Coord3& p0 = rawknots[kidx];
+		const Coord3& p1 = rawknots[kidx+1];
+
+		// Get neighboring points for polynomial interpolation
+		const Coord3 pm1 = kidx > 0 ? rawknots[kidx-1] : p0;
+		const Coord3 p2 = kidx < nrknots-2 ? rawknots[kidx+2] : p1;
+
+		// Interpolate between p0 and p1 using 4-point polynomial
+		for ( int step=0; step<interpsteps; step++ )
+		{
+			const float t = float(step) / float(interpsteps);
+
+			// Catmull-Rom spline interpolation
+			const float t2 = t * t;
+			const float t3 = t2 * t;
+
+			Coord3 interp;
+			interp.x_ = 0.5f * ((2.0f*p0.x_) +
+				(-pm1.x_ + p1.x_) * t +
+				(2.0f*pm1.x_ - 5.0f*p0.x_ + 4.0f*p1.x_ - p2.x_) * t2 +
+				(-pm1.x_ + 3.0f*p0.x_ - 3.0f*p1.x_ + p2.x_) * t3);
+			interp.y_ = 0.5f * ((2.0f*p0.y_) +
+				(-pm1.y_ + p1.y_) * t +
+				(2.0f*pm1.y_ - 5.0f*p0.y_ + 4.0f*p1.y_ - p2.y_) * t2 +
+				(-pm1.y_ + 3.0f*p0.y_ - 3.0f*p1.y_ + p2.y_) * t3);
+			interp.z_ = 0.5f * ((2.0f*p0.z_) +
+				(-pm1.z_ + p1.z_) * t +
+				(2.0f*pm1.z_ - 5.0f*p0.z_ + 4.0f*p1.z_ - p2.z_) * t2 +
+				(-pm1.z_ + 3.0f*p0.z_ - 3.0f*p1.z_ + p2.z_) * t3);
+
+			nearestpolygonmarker_->getCoordinates()->addPos( interp );
+		}
+		}
+
+		// Add the final knot
+		nearestpolygonmarker_->getCoordinates()->addPos( rawknots[nrknots-1] );
+
+		// If closed, interpolate from last knot back to first
+		if ( polygonclosed_ && nrknots > 2 )
+		{
+		const Coord3& p0 = rawknots[nrknots-1];
+		const Coord3& p1 = rawknots[0];
+		const Coord3& pm1 = rawknots[nrknots-2];
+		const Coord3& p2 = rawknots[1];
+
+		for ( int step=1; step<=interpsteps; step++ )
+		{
+			const float t = float(step) / float(interpsteps);
+			const float t2 = t * t;
+			const float t3 = t2 * t;
+
+			Coord3 interp;
+			interp.x_ = 0.5f * ((2.0f*p0.x_) +
+				(-pm1.x_ + p1.x_) * t +
+				(2.0f*pm1.x_ - 5.0f*p0.x_ + 4.0f*p1.x_ - p2.x_) * t2 +
+				(-pm1.x_ + 3.0f*p0.x_ - 3.0f*p1.x_ + p2.x_) * t3);
+			interp.y_ = 0.5f * ((2.0f*p0.y_) +
+				(-pm1.y_ + p1.y_) * t +
+				(2.0f*pm1.y_ - 5.0f*p0.y_ + 4.0f*p1.y_ - p2.y_) * t2 +
+				(-pm1.y_ + 3.0f*p0.y_ - 3.0f*p1.y_ + p2.y_) * t3);
+			interp.z_ = 0.5f * ((2.0f*p0.z_) +
+				(-pm1.z_ + p1.z_) * t +
+				(2.0f*pm1.z_ - 5.0f*p0.z_ + 4.0f*p1.z_ - p2.z_) * t2 +
+				(-pm1.z_ + 3.0f*p0.z_ - 3.0f*p1.z_ + p2.z_) * t3);
+
+			nearestpolygonmarker_->getCoordinates()->addPos( interp );
+		}
+		}
+
+		// Create primitive set for line strip
+		const int nrpoints = nearestpolygonmarker_->getCoordinates()->size();
+		if ( nrpoints >= 2 )
+		{
+		// Build sequential indices
+		TypeSet<int> indices;
+		for ( int idx=0; idx<nrpoints; idx++ )
+			indices += idx;
+
+		RefMan<Geometry::IndexedPrimitiveSet> primitiveset =
+			Geometry::IndexedPrimitiveSet::create( false );
+		primitiveset->setPrimitiveType( Geometry::PrimitiveSet::LineStrips );
+		primitiveset->append( indices.arr(), indices.size() );
+		nearestpolygonmarker_->addPrimitiveSet( primitiveset.ptr() );
+
+		nearestpolygonmarker_->turnOn( true );
+		}
+		else
+		{
+		nearestpolygonmarker_->turnOn( false );
+		}
+	}
+	else
+	{
+		nearestpolygonmarker_->turnOn( false );
+	}
+	}
 }
 
 
 void PolygonBodyDisplay::showManipulator( bool yn )
 {
-    if ( showmanipulator_==yn )
+	if ( showmanipulator_==yn )
 	return;
 
-    showmanipulator_ = yn;
-    updatePolygonDisplay();
-    updateManipulator();
+	showmanipulator_ = yn;
+
+	// When showing manipulator (editing mode), request interact mode
+	if ( yn && scene_ )
+	{
+	// Signal that we need interact mode
+	scene_->objectMoved( nullptr );
+	}
+
+	updatePolygonDisplay();
+	updateManipulator();
 }
 
 

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -690,6 +690,11 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 			eraseendpos_ = pos;
 			eventcatcher_->setHandled();
 		}
+		else
+		{
+			// Invalid position - reset state
+			iserasing_ = false;
+		}
 		return;
 		}
 		else if ( eventinfo.type == visBase::MouseMovement && eventinfo.pressed )
@@ -699,8 +704,10 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 		{
 			Coord3 pos = disp2world( eventinfo.displaypickedpos );
 			if ( pos.isDefined() )
+			{
 			eraseendpos_ = pos;
 			eventcatcher_->setHandled();
+			}
 		}
 		return;
 		}
@@ -730,16 +737,35 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 				// It was just a click - delete single nearest point
 				eraseKnotsNearPosition( pos );
 			}
-
-			iserasing_ = false;
 			}
+
+			// Always reset state after release
+			iserasing_ = false;
+			erasestartpos_ = Coord3::udf();
+			eraseendpos_ = Coord3::udf();
 			eventcatcher_->setHandled();
 		}
 		return;
 		}
+		else if ( !eventinfo.pressed && !iserasing_ )
+		{
+		// Ctrl is held but we're not in erase mode - might be leftover state
+		// Make sure state is clean
+		iserasing_ = false;
+		erasestartpos_ = Coord3::udf();
+		eraseendpos_ = Coord3::udf();
+		}
 	}
 	else
 	{
+		// Normal sowing mode - if we were erasing, cancel it
+		if ( iserasing_ )
+		{
+		iserasing_ = false;
+		erasestartpos_ = Coord3::udf();
+		eraseendpos_ = Coord3::udf();
+		}
+
 		// Normal sowing mode
 		polygonsurfeditor_->setSowingPivot( 
 		disp2world(viseditor_->sower().pivotPos()) );
@@ -886,7 +912,7 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 
 	const int activepolygon = 0;
 	const int nrknots = empolygonsurf_->geometry().nrKnots( activepolygon );
-	if ( nrknots == 0 )
+	if ( nrknots < 2 )
 	return;
 
 	// Get the geometry element to access knot positions
@@ -895,22 +921,9 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( !polygonsurface )
 	return;
 
-	// Get lateral (XY) bounds of the drag trajectory with margin
-	const double minx = mMIN( erasestartpos_.x_, eraseendpos_.x_ );
-	const double maxx = mMAX( erasestartpos_.x_, eraseendpos_.x_ );
-	const double miny = mMIN( erasestartpos_.y_, eraseendpos_.y_ );
-	const double maxy = mMAX( erasestartpos_.y_, eraseendpos_.y_ );
-
-	// Add margin to the rectangle to capture nearby points
-	const double margin = 100.0; // ~4 bins width for deletion tolerance
-	const double minx_margin = minx - margin;
-	const double maxx_margin = maxx + margin;
-	const double miny_margin = miny - margin;
-	const double maxy_margin = maxy + margin;
-
-	// SIMPLER APPROACH: Just identify and delete knots INSIDE the rectangle
-	// Build list of knot indices to delete (in reverse order)
-	TypeSet<int> indicestodelete;
+	// Step 1: Find the knot nearest to the start position (in 3D space)
+	int startknotidx = -1;
+	double mindist_start = 1e30;
 
 	for ( int idx=0; idx<nrknots; idx++ )
 	{
@@ -918,29 +931,143 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 	if ( !knotpos.isDefined() )
 		continue;
 
-	// Check if knot is INSIDE the drag rectangle (with margin)
-	const bool insiderectangle = (knotpos.x_ >= minx_margin && knotpos.x_ <= maxx_margin && 
-					  knotpos.y_ >= miny_margin && knotpos.y_ <= maxy_margin);
-
-	if ( insiderectangle )
+	const double dist = erasestartpos_.distTo( knotpos );
+	if ( dist < mindist_start )
 	{
-		indicestodelete += idx;
+		mindist_start = dist;
+		startknotidx = idx;
 	}
 	}
+
+	if ( startknotidx == -1 )
+	return;
+
+	// Step 2: Find the knot nearest to the end position
+	int endknotidx = -1;
+	double mindist_end = 1e30;
+
+	for ( int idx=0; idx<nrknots; idx++ )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, idx) );
+	if ( !knotpos.isDefined() )
+		continue;
+
+	const double dist = eraseendpos_.distTo( knotpos );
+	if ( dist < mindist_end )
+	{
+		mindist_end = dist;
+		endknotidx = idx;
+	}
+	}
+
+	if ( endknotidx == -1 || startknotidx == endknotidx )
+	return;
+
+	// Step 3: Determine deletion path by checking proximity to drag trajectory
+	// We want to delete knots that are close to the line segment from start to end
+
+	TypeSet<int> indicestodelete;
+
+	// Build both possible paths and check which one is closer to the drag trajectory
+	TypeSet<int> path1, path2;
+
+	// Path 1: From start to end going forward (increasing indices, wrapping if needed)
+	int idx = startknotidx;
+	while ( true )
+	{
+	path1 += idx;
+	if ( idx == endknotidx )
+		break;
+	idx = (idx + 1) % nrknots;
+	if ( path1.size() > nrknots )
+		break; // Safety check
+	}
+
+	// Path 2: From start to end going backward (decreasing indices, wrapping if needed)
+	idx = startknotidx;
+	while ( true )
+	{
+	path2 += idx;
+	if ( idx == endknotidx )
+		break;
+	idx = (idx - 1 + nrknots) % nrknots;
+	if ( path2.size() > nrknots )
+		break; // Safety check
+	}
+
+	// Calculate which path is closer to the drag trajectory
+	double avgdist_path1 = 0.0;
+	double avgdist_path2 = 0.0;
+	int count1 = 0, count2 = 0;
+
+	// For each knot in path1, calculate distance to drag line segment
+	for ( int i=0; i<path1.size(); i++ )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, path1[i]) );
+	if ( knotpos.isDefined() )
+	{
+		// Distance from point to line segment (simplified - using distance to midpoint)
+		const Coord3 dragmidpoint = (erasestartpos_ + eraseendpos_) * 0.5;
+		avgdist_path1 += knotpos.distTo( dragmidpoint );
+		count1++;
+	}
+	}
+	if ( count1 > 0 )
+	avgdist_path1 /= count1;
+
+	// For each knot in path2, calculate distance to drag line segment
+	for ( int i=0; i<path2.size(); i++ )
+	{
+	const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, path2[i]) );
+	if ( knotpos.isDefined() )
+	{
+		const Coord3 dragmidpoint = (erasestartpos_ + eraseendpos_) * 0.5;
+		avgdist_path2 += knotpos.distTo( dragmidpoint );
+		count2++;
+	}
+	}
+	if ( count2 > 0 )
+	avgdist_path2 /= count2;
+
+	// Choose the path that's closer to the drag trajectory
+	const TypeSet<int>& pathToDelete = (avgdist_path1 <= avgdist_path2) ? path1 : path2;
 
 	// Safety check: don't delete all knots
-	if ( indicestodelete.size() >= nrknots )
+	if ( pathToDelete.size() >= nrknots )
 	{
 	// Would delete everything - abort
 	return;
 	}
 
-	// Delete knots in reverse order (to maintain valid indices)
-	for ( int i=indicestodelete.size()-1; i>=0; i-- )
+	// Copy indices to delete
+	for ( int i=0; i<pathToDelete.size(); i++ )
+	indicestodelete += pathToDelete[i];
+
+	// Delete knots in reverse order of their indices (to maintain valid indices)
+	// Sort indices in descending order first
+	for ( int i=0; i<indicestodelete.size()-1; i++ )
+	{
+	for ( int j=i+1; j<indicestodelete.size(); j++ )
+	{
+		if ( indicestodelete[i] < indicestodelete[j] )
+		{
+		// Swap
+		const int temp = indicestodelete[i];
+		indicestodelete[i] = indicestodelete[j];
+		indicestodelete[j] = temp;
+		}
+	}
+	}
+
+	// Now delete in descending order
+	for ( int i=0; i<indicestodelete.size(); i++ )
 	{
 	const int knotidx = indicestodelete[i];
-	const EM::SubID subid = RowCol(activepolygon, knotidx).toInt64();
-	empolygonsurf_->geometry().removeKnot( subid, true );
+	if ( knotidx >= 0 && knotidx < empolygonsurf_->geometry().nrKnots(activepolygon) )
+	{
+		const EM::SubID subid = RowCol(activepolygon, knotidx).toInt64();
+		empolygonsurf_->geometry().removeKnot( subid, true );
+	}
 	}
 
 	// Update undo and display

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -23,8 +23,6 @@ ________________________________________________________________________
 #include "vispolygonoffset.h"
 #include "vistristripset.h"
 
-#include <osg/Node>
-
 
 namespace visSurvey
 {
@@ -305,17 +303,8 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 	OD::LineStyle lnstyle( OD::LineStyle::Solid, 3, OD::Color(255, 255, 0) );
 	openpolygonline_->setLineStyle( lnstyle );
 
-	// CRITICAL: Add to scene root, not as child of this object
-	// This keeps it visible even when PolygonBodyDisplay is deselected
-	if ( scene_ )
-	{
-		scene_->addObject( openpolygonline_.ptr() );
-	}
-	else
-	{
-		// Fallback: add as child if no scene
-		addChild( openpolygonline_->osgNode() );
-	}
+	// Add to scene graph
+	addChild( openpolygonline_->osgNode() );
 
 	// Note: setLineStyle with width>0 automatically turns it on (line 100 in vispolyline.cc)
 	}
@@ -350,19 +339,15 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
     if ( polygonsurfeditor )
 	polygonsurfeditor->addUser();
 
-	viseditor_->setEditor( polygonsurfeditor_.ptr() );
-	bodydisplay_->turnOn( true );
+    viseditor_->setEditor( polygonsurfeditor_.ptr() );
+    bodydisplay_->turnOn( true );
+    displaypolygons_ = false;
 
-	// For new polygons being drawn, show polygons by default (not body yet)
-	// This ensures the polygon line is visible when drawing
-	displaypolygons_ = true;
-	display( true, false );  // Show polygons, hide body
+    nontexturecol_ = empolygonsurf_->preferredColor();
+    updateSingleColor();
+    updatePolygonDisplay();
 
-	nontexturecol_ = empolygonsurf_->preferredColor();
-	updateSingleColor();
-	updatePolygonDisplay();
-
-	return true;
+    return true;
 }
 
 
@@ -411,17 +396,12 @@ void PolygonBodyDisplay::touchAll( bool yn, bool updatemarker )
 	// Notify that coordinates have changed
 	openpolygonline_->dirtyCoordinates();
 
-	// Keep the polygon line visible even when not selected
 	// Only turn on line if we have at least 2 points
 	const int nrpoints = openpolygonline_->size();
 	if ( nrpoints >= 2 )
 		openpolygonline_->turnOn( true );
 	else
 		openpolygonline_->turnOn( false );
-
-	// Ensure the line stays on even if the object is deselected
-	// This allows the polygon to remain visible in the scene
-	openpolygonline_->enableTraversal( visBase::cDraggerIntersecTraversalMask() );
 	}
 	else
 	{
@@ -523,34 +503,6 @@ void PolygonBodyDisplay::updatePolygonDisplay()
 
 	// Never show the default Bezier polygon display - we use custom openpolygonline_ instead
 	polygondisplay_->turnOn( false );
-}
-
-
-bool PolygonBodyDisplay::turnOn( bool yn )
-{
-	// Call base class and get previous state
-	const bool wason = visBase::VisualObjectImpl::turnOn( yn );
-
-	// CRITICAL: Keep polygon line visible ALWAYS
-	// Force it on regardless of parent's state
-	if ( openpolygonline_ )
-	{
-	const int nrpoints = openpolygonline_->size();
-	if ( nrpoints >= 2 )
-	{
-		// Force the line to stay visible by calling turnOn on it directly
-		// This overrides any parent state changes
-		openpolygonline_->turnOn( true );
-
-		// Also ensure its OSG node is enabled
-		if ( openpolygonline_->osgNode() )
-		{
-		openpolygonline_->osgNode()->setNodeMask( ~0 );  // All bits set = fully visible
-		}
-	}
-	}
-
-	return wason;
 }
 
 
@@ -911,19 +863,108 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 	// The geometry supports this - polygonclosed_ is just a visual flag
 	// Just ensure the event is handled to prevent deselection
 
-	// Handle sower activation on press for drag mode
-	// Works for both open and closed polygons
+	// SIMPLIFIED DRAG HANDLING
+	// Rule 1: First drag (no polygon) - always use sower
+	// Rule 2: Drag from first point - prepend (for future implementation)
+	// Rule 3: Drag from last point - append
+	// Rule 4: Drag from middle - DO NOTHING (disabled)
+
+	// Handle sower activation on press
 	if ( eventinfo.pressed )
 	{
-	// Try to activate sower for click-and-drag
-	const OD::Color& prefcol = empolygonsurf_->preferredColor();
-	if ( viseditor_->sower().activate(prefcol, eventinfo) )
+	if ( !empolygonsurf_ )
 		return;
+
+	const int activepolygon = 0;
+	const int nrpolygons = empolygonsurf_->geometry().nrPolygons();
+	const int nrknots = (nrpolygons > 0) ? empolygonsurf_->geometry().nrKnots(activepolygon) : 0;
+
+	if ( nrpolygons == 0 || nrknots == 0 )
+	{
+		// No polygon yet or empty polygon - always use sower for initial creation
+		const OD::Color& prefcol = empolygonsurf_->preferredColor();
+		if ( viseditor_->sower().activate(prefcol, eventinfo) )
+		{
+		isdragging_ = true;
+		draginsertmode_ = 0; // Append
+		return;
+		}
+	}
+	else if ( nrknots > 0 )
+	{
+		// Polygon exists - check if dragging from first or last point
+		mDynamicCastGet( Geometry::PolygonSurface*, polygonsurface,
+				 empolygonsurf_->geometryElement() )
+		if ( !polygonsurface )
+		return;
+
+		// Get sampling intervals
+		const double inl_dist = SI().inlDistance();
+		const double crl_dist = SI().crlDistance();
+		const double z_step = SI().zStep();
+		const double xy_step = (inl_dist + crl_dist) / 2.0;
+
+		// Find nearest knot to drag start
+		int nearest_idx = -1;
+		double min_dist = 1e30;
+
+		for ( int idx=0; idx<nrknots; idx++ )
+		{
+		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, idx) );
+		if ( !knotpos.isDefined() )
+			continue;
+
+		const double dx_norm = (knotpos.x_ - pos.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - pos.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - pos.z_) / z_step;
+		const double dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+
+		if ( dist < min_dist )
+		{
+			min_dist = dist;
+			nearest_idx = idx;
+		}
+		}
+
+		// Only allow drag from first or last point
+		if ( nearest_idx == 0 )
+		{
+		// Drag from first point - use sower for prepend (future: change to mode 1)
+		draginsertmode_ = 0; // For now, append
+		const OD::Color& prefcol = empolygonsurf_->preferredColor();
+		if ( viseditor_->sower().activate(prefcol, eventinfo) )
+		{
+			isdragging_ = true;
+			return;
+		}
+		}
+		else if ( nearest_idx == nrknots - 1 )
+		{
+		// Drag from last point - use sower for append
+		draginsertmode_ = 0; // Append
+		const OD::Color& prefcol = empolygonsurf_->preferredColor();
+		if ( viseditor_->sower().activate(prefcol, eventinfo) )
+		{
+			isdragging_ = true;
+			return;
+		}
+		}
+		else
+		{
+		// Drag from middle - DO NOTHING
+		// Don't activate sower, mark event as handled to prevent click insertion
+		eventcatcher_->setHandled();
+		return;
+		}
+	}
 
 	return; // Don't add point on press, wait for release
 	}
 
 	// On release, continue to point insertion
+	// Reset drag state - if we reach here, it's a single click (not drag)
+	isdragging_ = false;
+	draginsertmode_ = 0;
 
 	// Only add points on mouse release
 	// Determine edit normal from plane
@@ -942,7 +983,7 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 	const int nrpolygons = empolygonsurf_->geometry().nrPolygons();
 	const int activepolygon = 0;
 
-	// If no polygon exists, create one
+	// If no polygon exists, create one with the first point
 	if ( nrpolygons == 0 )
 	{
 	if ( !empolygonsurf_->geometry().insertPolygon(
@@ -950,6 +991,15 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 		return;
 
 	polygonclosed_ = false; // Start with open polygon
+
+	// Polygon created with first point - done for this point
+	// Subsequent drag points will go through the else block below
+	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
+		EM::EMM().undo(empolygonsurf_->id()).currentEventID() );
+	touchAll( false );
+	polygonsurfeditor_->editpositionchange.trigger();
+	eventcatcher_->setHandled();
+	return;
 	}
 	else
 	{
@@ -977,88 +1027,144 @@ void PolygonBodyDisplay::mouseCB( CallBacker* cb )
 		return;
 	}
 
-	// Smart mode detection: Insert between neighbors OR add at end
-	// Decision based on: Are we clicking NEAR an existing line segment?
+	// REFINED INSERTION ALGORITHM:
+	// For DRAG mode: Use consistent prepend/append
+	// For CLICK mode: Find nearest knot and determine best insertion point
 
-	bool shouldInsertBetweenNeighbors = false;
+	// Get sampling intervals for normalized distance calculation
+	const double inl_dist = SI().inlDistance();
+	const double crl_dist = SI().crlDistance();
+	const double z_step = SI().zStep();
+	const double xy_step = (inl_dist + crl_dist) / 2.0;
 
-	// Check if we have valid neighbors and insertion point
-	if ( nrknots >= 2 && !insertpid.isUdf() && !nearestpid0.isUdf() && !nearestpid1.isUdf() )
+	int insert_position = -1;
+
+	if ( isdragging_ )
 	{
-		// Get the two nearest knot positions
-		const RowCol rc0 = nearestpid0.getRowCol();
-		const RowCol rc1 = nearestpid1.getRowCol();
-		const Coord3 knotpos0 = polygonsurface->getKnot( rc0 );
-		const Coord3 knotpos1 = polygonsurface->getKnot( rc1 );
-
-		if ( knotpos0.isDefined() && knotpos1.isDefined() )
-		{
-		// Calculate distance from click position to the line segment between neighbors
-		const Coord3 segvec = knotpos1 - knotpos0;
-		const double seglen = segvec.abs();
-
-		if ( seglen > 0.001 )
-		{
-			// Project click position onto the line segment
-			const Coord3 clickvec = pos - knotpos0;
-			const double t = clickvec.dot(segvec) / (seglen * seglen);
-			const double t_clamped = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
-			const Coord3 projection = knotpos0 + segvec * t_clamped;
-
-			// Calculate distance to line segment
-			const double dist_to_segment = pos.distTo( projection );
-
-			// Use normalized distance threshold (in sample space)
-			const double inl_dist = SI().inlDistance();
-			const double crl_dist = SI().crlDistance();
-			const double xy_step = (inl_dist + crl_dist) / 2.0;
-			const double threshold_distance = xy_step * 2.0; // 2 bins away
-
-			// If click is close to the line segment, insert between neighbors
-			if ( dist_to_segment < threshold_distance )
-			{
-			shouldInsertBetweenNeighbors = true;
-			}
-		}
-		}
-	}
-
-	// Execute the appropriate insertion strategy
-	if ( shouldInsertBetweenNeighbors )
-	{
-		// INSERT MODE: Click is near existing line - insert between neighbors
-		const RowCol insertrc = insertpid.getRowCol();
-		const int insertcol = insertrc.col();
-
-		if ( insertcol >= 0 && insertcol <= nrknots )
-		{
-		if ( !empolygonsurf_->geometry().insertKnot(insertpid.subID(), pos, true) )
-		{
-			eventcatcher_->setHandled();
-			return;
-		}
-		}
-		else
-		{
-		// Fallback to end if insertion position invalid
-		const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
-		if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
-		{
-			eventcatcher_->setHandled();
-			return;
-		}
-		}
+		// DRAG MODE: Always append - simplest, most predictable
+		insert_position = nrknots;
 	}
 	else
 	{
-		// CONSTRUCTION MODE: Click is away from polygon - add at end
-		const EM::SubID subid = RowCol(activepolygon, nrknots).toInt64();
-		if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+		// CLICK MODE: Find nearest knot and determine insertion strategy
+		int nearest_knot_idx = -1;
+		double min_dist = 1e30;
+
+		for ( int idx=0; idx<nrknots; idx++ )
+		{
+		const Coord3 knotpos = polygonsurface->getKnot( RowCol(activepolygon, idx) );
+		if ( !knotpos.isDefined() )
+			continue;
+
+		// Normalized distance in sample space
+		const double dx_norm = (knotpos.x_ - pos.x_) / xy_step;
+		const double dy_norm = (knotpos.y_ - pos.y_) / xy_step;
+		const double dz_norm = (knotpos.z_ - pos.z_) / z_step;
+		const double dist = sqrt(dx_norm*dx_norm + dy_norm*dy_norm + dz_norm*dz_norm);
+
+		if ( dist < min_dist )
+		{
+			min_dist = dist;
+			nearest_knot_idx = idx;
+		}
+		}
+
+		if ( nearest_knot_idx == -1 )
 		{
 		eventcatcher_->setHandled();
 		return;
 		}
+
+		// Determine insertion position based on nearest knot
+		if ( nearest_knot_idx == 0 )
+		{
+		// Case 1: Nearest is FIRST point - insert at beginning
+		insert_position = 0;
+		}
+		else if ( nearest_knot_idx == nrknots - 1 )
+		{
+		// Case 2: Nearest is LAST point - add at end
+		insert_position = nrknots;
+		}
+		else
+		{
+		// Case 3: Nearest is MIDDLE point - find which neighbor is closer
+		// Better approach: check which SEGMENT the new point is closest to
+		const int prev_idx = nearest_knot_idx - 1;
+		const int next_idx = nearest_knot_idx + 1;
+
+		const Coord3 nearest_pos = polygonsurface->getKnot( RowCol(activepolygon, nearest_knot_idx) );
+		const Coord3 prev_pos = polygonsurface->getKnot( RowCol(activepolygon, prev_idx) );
+		const Coord3 next_pos = polygonsurface->getKnot( RowCol(activepolygon, next_idx) );
+
+		double dist_to_prev_segment = 1e30;
+		double dist_to_next_segment = 1e30;
+
+		// Distance to segment between prev and nearest
+		if ( prev_pos.isDefined() && nearest_pos.isDefined() )
+		{
+			const Coord3 segvec = nearest_pos - prev_pos;
+			const double seglen = segvec.abs();
+			if ( seglen > 0.001 )
+			{
+			const Coord3 pointvec = pos - prev_pos;
+			double t = pointvec.dot(segvec) / (seglen * seglen);
+			t = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+			const Coord3 projection = prev_pos + segvec * t;
+			dist_to_prev_segment = pos.distTo( projection );
+			}
+		}
+
+		// Distance to segment between nearest and next
+		if ( nearest_pos.isDefined() && next_pos.isDefined() )
+		{
+			const Coord3 segvec = next_pos - nearest_pos;
+			const double seglen = segvec.abs();
+			if ( seglen > 0.001 )
+			{
+			const Coord3 pointvec = pos - nearest_pos;
+			double t = pointvec.dot(segvec) / (seglen * seglen);
+			t = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+			const Coord3 projection = nearest_pos + segvec * t;
+			dist_to_next_segment = pos.distTo( projection );
+			}
+		}
+
+		// Insert on the segment that's closer
+		if ( dist_to_prev_segment <= dist_to_next_segment )
+		{
+		// Closer to prev-nearest segment - insert between them
+		insert_position = nearest_knot_idx;
+		}
+		else
+		{
+		// Closer to nearest-next segment - insert between them
+		insert_position = next_idx;
+		}
+		}
 	}
+
+	// Reset drag state after insertion (in case sower adds multiple points)
+	// We'll keep the mode consistent for the entire drag operation
+	// isdragging_ will be reset when drag finishes
+
+	// Perform the insertion
+	const EM::SubID subid = RowCol(activepolygon, insert_position).toInt64();
+	if ( !empolygonsurf_->geometry().insertKnot(subid, pos, true) )
+	{
+		eventcatcher_->setHandled();
+		// Reset drag state on failure
+		isdragging_ = false;
+		draginsertmode_ = 0;
+		return;
+	}
+
+	// If this was a single click (not dragging), reset drag state
+	if ( !isdragging_ )
+	{
+		draginsertmode_ = 0;
+	}
+	// If dragging, keep the state for subsequent points in the drag
 	}
 
 	EM::EMM().undo(empolygonsurf_->id()).setUserInteractionEnd(
@@ -1356,10 +1462,12 @@ void PolygonBodyDisplay::eraseKnotsBetweenDragPositions()
 
 void PolygonBodyDisplay::sowingFinishedCB( CallBacker* )
 {
-	// The sower has finished, update the display
-	// Note: We can't access sowinghistory_ directly as it's private
-	// The points should have been added already by the standard mechanism
-	// Just update the display
+	// The sower has finished
+	// Reset drag state
+	isdragging_ = false;
+	draginsertmode_ = 0;
+
+	// Update the display
 	touchAll( false );
 }
 

--- a/src/visSurvey/vispolygonbodydisplay.cc
+++ b/src/visSurvey/vispolygonbodydisplay.cc
@@ -23,6 +23,8 @@ ________________________________________________________________________
 #include "vispolygonoffset.h"
 #include "vistristripset.h"
 
+#include <osg/Node>
+
 
 namespace visSurvey
 {
@@ -303,8 +305,17 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
 	OD::LineStyle lnstyle( OD::LineStyle::Solid, 3, OD::Color(255, 255, 0) );
 	openpolygonline_->setLineStyle( lnstyle );
 
-	// Add to scene graph
-	addChild( openpolygonline_->osgNode() );
+	// CRITICAL: Add to scene root, not as child of this object
+	// This keeps it visible even when PolygonBodyDisplay is deselected
+	if ( scene_ )
+	{
+		scene_->addObject( openpolygonline_.ptr() );
+	}
+	else
+	{
+		// Fallback: add as child if no scene
+		addChild( openpolygonline_->osgNode() );
+	}
 
 	// Note: setLineStyle with width>0 automatically turns it on (line 100 in vispolyline.cc)
 	}
@@ -339,15 +350,19 @@ bool PolygonBodyDisplay::setEMID( const EM::ObjectID& emid )
     if ( polygonsurfeditor )
 	polygonsurfeditor->addUser();
 
-    viseditor_->setEditor( polygonsurfeditor_.ptr() );
-    bodydisplay_->turnOn( true );
-    displaypolygons_ = false;
+	viseditor_->setEditor( polygonsurfeditor_.ptr() );
+	bodydisplay_->turnOn( true );
 
-    nontexturecol_ = empolygonsurf_->preferredColor();
-    updateSingleColor();
-    updatePolygonDisplay();
+	// For new polygons being drawn, show polygons by default (not body yet)
+	// This ensures the polygon line is visible when drawing
+	displaypolygons_ = true;
+	display( true, false );  // Show polygons, hide body
 
-    return true;
+	nontexturecol_ = empolygonsurf_->preferredColor();
+	updateSingleColor();
+	updatePolygonDisplay();
+
+	return true;
 }
 
 
@@ -396,12 +411,17 @@ void PolygonBodyDisplay::touchAll( bool yn, bool updatemarker )
 	// Notify that coordinates have changed
 	openpolygonline_->dirtyCoordinates();
 
+	// Keep the polygon line visible even when not selected
 	// Only turn on line if we have at least 2 points
 	const int nrpoints = openpolygonline_->size();
 	if ( nrpoints >= 2 )
 		openpolygonline_->turnOn( true );
 	else
 		openpolygonline_->turnOn( false );
+
+	// Ensure the line stays on even if the object is deselected
+	// This allows the polygon to remain visible in the scene
+	openpolygonline_->enableTraversal( visBase::cDraggerIntersecTraversalMask() );
 	}
 	else
 	{
@@ -503,6 +523,34 @@ void PolygonBodyDisplay::updatePolygonDisplay()
 
 	// Never show the default Bezier polygon display - we use custom openpolygonline_ instead
 	polygondisplay_->turnOn( false );
+}
+
+
+bool PolygonBodyDisplay::turnOn( bool yn )
+{
+	// Call base class and get previous state
+	const bool wason = visBase::VisualObjectImpl::turnOn( yn );
+
+	// CRITICAL: Keep polygon line visible ALWAYS
+	// Force it on regardless of parent's state
+	if ( openpolygonline_ )
+	{
+	const int nrpoints = openpolygonline_->size();
+	if ( nrpoints >= 2 )
+	{
+		// Force the line to stay visible by calling turnOn on it directly
+		// This overrides any parent state changes
+		openpolygonline_->turnOn( true );
+
+		// Also ensure its OSG node is enabled
+		if ( openpolygonline_->osgNode() )
+		{
+		openpolygonline_->osgNode()->setNodeMask( ~0 );  // All bits set = fully visible
+		}
+	}
+	}
+
+	return wason;
 }
 
 

--- a/src/visSurvey/vissower.cc
+++ b/src/visSurvey/vissower.cc
@@ -39,7 +39,7 @@ Sower::Sower( visBase::VisualObjectImpl* editobj )
     sowingline_ = visBase::PolyLine::create();
     RefMan<visBase::Material> newmat = visBase::Material::create();
     sowingline_->setMaterial( newmat.ptr() );
-    sowingline_->setLineStyle( OD::LineStyle(OD::LineStyle::Solid,1) );
+    sowingline_->setLineStyle( OD::LineStyle(OD::LineStyle::Solid,2) );
     sowingline_->setPickable( false, false );
     addChild( sowingline_->osgNode() );
     reInitSettings();


### PR DESCRIPTION
Changed the way we create and edit normal polygons. Smoother, dragging, control-dragging, clicking, control-click. Also solved a bug on display on sections only, which occurs in v7 as well. When toggled on and you toggle the section off, neither pointsets, not polygons disappear in v7. 

Note, you can ignore all changes to vispolygonbody.cc and .h. I implemented the same polygon creation and editing option but this destroys the creation of geobodies. I will work on this after continuing my work on the ML workflow.